### PR TITLE
Add "same as" support

### DIFF
--- a/devices/airgradient/airgradient/i-1psl/info.yaml
+++ b/devices/airgradient/airgradient/i-1psl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AirGradient
 manufacturer_raw: AirGradient
 model_name: I-1PSL
 model_raw: I-1PSL
+same_as: null
 versions:
 - software: 3.0.9
 via_devices: null

--- a/devices/airgradient/airgradient/i-9psl/info.yaml
+++ b/devices/airgradient/airgradient/i-9psl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AirGradient
 manufacturer_raw: AirGradient
 model_name: I-9PSL
 model_raw: I-9PSL
+same_as: null
 versions:
 - software: 3.1.1
 via_devices: null

--- a/devices/airgradient/airgradient/o-1ppt/info.yaml
+++ b/devices/airgradient/airgradient/o-1ppt/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AirGradient
 manufacturer_raw: AirGradient
 model_name: O-1PPT
 model_raw: O-1PPT
+same_as: null
 versions:
 - software: 3.1.1
 via_devices: null

--- a/devices/airgradient/airgradient/o-1pst/info.yaml
+++ b/devices/airgradient/airgradient/o-1pst/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AirGradient
 manufacturer_raw: AirGradient
 model_name: O-1PST
 model_raw: O-1PST
+same_as: null
 versions:
 - software: 3.0.10beta2
 via_devices: null

--- a/devices/androidtv/google/chromecast/info.yaml
+++ b/devices/androidtv/google/chromecast/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Chromecast
 model_raw: Chromecast
+same_as: null
 versions:
 - software: 1.55.3-play
 via_devices: null

--- a/devices/androidtv_remote/google/chromecast/info.yaml
+++ b/devices/androidtv_remote/google/chromecast/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Chromecast
 model_raw: Chromecast
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/androidtv_remote/hisense/smarttv-4k/info.yaml
+++ b/devices/androidtv_remote/hisense/smarttv-4k/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hisense
 manufacturer_raw: Hisense
 model_name: SmartTV 4K
 model_raw: SmartTV 4K
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/androidtv_remote/nvidia/shield-android-tv/info.yaml
+++ b/devices/androidtv_remote/nvidia/shield-android-tv/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: NVIDIA
 manufacturer_raw: NVIDIA
 model_name: SHIELD Android TV
 model_raw: SHIELD Android TV
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/androidtv_remote/sony/bravia-4k-gb-atv3/info.yaml
+++ b/devices/androidtv_remote/sony/bravia-4k-gb-atv3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sony
 manufacturer_raw: Sony
 model_name: BRAVIA 4K GB ATV3
 model_raw: BRAVIA 4K GB ATV3
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/androidtv_remote/tcl/smart-tv-pro/info.yaml
+++ b/devices/androidtv_remote/tcl/smart-tv-pro/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TCL
 manufacturer_raw: TCL
 model_name: Smart TV Pro
 model_raw: Smart TV Pro
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/androidtv_remote/xgimi/xk03h/info.yaml
+++ b/devices/androidtv_remote/xgimi/xk03h/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: XGIMI
 manufacturer_raw: XGIMI
 model_name: XK03H
 model_raw: XK03H
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/apple_tv/apple/apple-tv-4k-gen-2/info.yaml
+++ b/devices/apple_tv/apple/apple-tv-4k-gen-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Apple TV 4K (gen 2)
 model_raw: Apple TV 4K (gen 2)
+same_as: null
 versions:
 - software: '17.4'
 via_devices: null

--- a/devices/apple_tv/apple/apple-tv-4k-gen-3/info.yaml
+++ b/devices/apple_tv/apple/apple-tv-4k-gen-3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Apple TV 4K (gen 3)
 model_raw: Apple TV 4K (gen 3)
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/apple_tv/apple/apple-tv-4k/info.yaml
+++ b/devices/apple_tv/apple/apple-tv-4k/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Apple TV 4K
 model_raw: Apple TV 4K
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/apple_tv/apple/ecb601/info.yaml
+++ b/devices/apple_tv/apple/ecb601/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: ECB601
 model_raw: ECB601
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/apple_tv/apple/homepod-gen-2/info.yaml
+++ b/devices/apple_tv/apple/homepod-gen-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: HomePod (gen 2)
 model_raw: HomePod (gen 2)
+same_as: null
 versions:
 - software: '17.5'
 via_devices: null

--- a/devices/apple_tv/apple/homepod-mini/info.yaml
+++ b/devices/apple_tv/apple/homepod-mini/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: HomePod Mini
 model_raw: HomePod Mini
+same_as: null
 versions:
 - software: '17.5'
 - software: '17.4'

--- a/devices/apple_tv/apple/homepod/info.yaml
+++ b/devices/apple_tv/apple/homepod/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: HomePod
 model_raw: HomePod
+same_as: null
 versions:
 - software: '17.5'
 via_devices: null

--- a/devices/apple_tv/apple/onelink-safe-sound/info.yaml
+++ b/devices/apple_tv/apple/onelink-safe-sound/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Onelink Safe Sound
 model_raw: Onelink Safe Sound
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/apple_tv/apple/qrq60/info.yaml
+++ b/devices/apple_tv/apple/qrq60/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: QRQ60
 model_raw: QRQ60
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/apple_tv/apple/roam/info.yaml
+++ b/devices/apple_tv/apple/roam/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Roam
 model_raw: Roam
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/apple_tv/sonos/one/info.yaml
+++ b/devices/apple_tv/sonos/one/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: One
 model_raw: One
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/asuswrt/asus/rt-ax58u-epa/info.yaml
+++ b/devices/asuswrt/asus/rt-ax58u-epa/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Asus
 manufacturer_raw: Asus
 model_name: RT-AX58U_EPA
 model_raw: RT-AX58U_EPA
+same_as: null
 versions:
 - software: 3.0.0.4 (build 388)
 via_devices: null

--- a/devices/august/august-home-inc/ak-r1/info.yaml
+++ b/devices/august/august-home-inc/ak-r1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AK-R1
 model_raw: AK-R1
+same_as: null
 versions:
 - software: 2.27.0
 via_devices: null

--- a/devices/august/august-home-inc/aug-md01/info.yaml
+++ b/devices/august/august-home-inc/aug-md01/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AUG-MD01
 model_raw: AUG-MD01
+same_as: null
 versions:
 - software: 2.8.0-2.0.5
 - software: 2.7.0-2.0.5

--- a/devices/august/august-home-inc/aug-mdy1/info.yaml
+++ b/devices/august/august-home-inc/aug-mdy1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AUG-MDY1
 model_raw: AUG-MDY1
+same_as: null
 versions:
 - software: 2.2.5
 - software: 2.7.0-2.0.5

--- a/devices/august/august-home-inc/aug-sl03-c02-g03/info.yaml
+++ b/devices/august/august-home-inc/aug-sl03-c02-g03/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AUG-SL03-C02-G03
 model_raw: AUG-SL03-C02-G03
+same_as: null
 versions:
 - software: 2.0.6
 - software: 1.59.0-2.0.6

--- a/devices/august/august-home-inc/aug-sl03-m03-g03/info.yaml
+++ b/devices/august/august-home-inc/aug-sl03-m03-g03/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AUG-SL03-M03-G03
 model_raw: AUG-SL03-M03-G03
+same_as: null
 versions:
 - software: 1.59.0-2.0.6
 via_devices: null

--- a/devices/august/august-home-inc/ayr202-cba2-usa/info.yaml
+++ b/devices/august/august-home-inc/ayr202-cba2-usa/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: AYR202-CBA2-USA
 model_raw: AYR202-CBA2-USA
+same_as: null
 versions:
 - software: 2.8.0-2.1.18
 via_devices: null

--- a/devices/august/august-home-inc/beta211123/info.yaml
+++ b/devices/august/august-home-inc/beta211123/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: BETA211123
 model_raw: BETA211123
+same_as: null
 versions:
 - software: 1.3.16
 via_devices: null

--- a/devices/august/august-home-inc/ies-d210w-g0/info.yaml
+++ b/devices/august/august-home-inc/ies-d210w-g0/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: IES-D210W-G0
 model_raw: IES-D210W-G0
+same_as: null
 versions:
 - software: 3.0.10-2.0.8
 via_devices: null

--- a/devices/august/august-home-inc/md-01/info.yaml
+++ b/devices/august/august-home-inc/md-01/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: MD-01
 model_raw: MD-01
+same_as: null
 versions:
 - software: 2.0.5
 via_devices: null

--- a/devices/august/august-home-inc/test200228/info.yaml
+++ b/devices/august/august-home-inc/test200228/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: TEST200228
 model_raw: TEST200228
+same_as: null
 versions:
 - software: 2.0.0-1.0.16
 via_devices: null

--- a/devices/august/august-home-inc/yrd450-n-ble-619/info.yaml
+++ b/devices/august/august-home-inc/yrd450-n-ble-619/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: YRD450-N-BLE-619
 model_raw: YRD450-N-BLE-619
+same_as: null
 versions:
 - software: 1.0.19
 via_devices: null

--- a/devices/august/august-home-inc/yrd450-n-ble-bsp/info.yaml
+++ b/devices/august/august-home-inc/yrd450-n-ble-bsp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: YRD450-N-BLE-BSP
 model_raw: YRD450-N-BLE-BSP
+same_as: null
 versions:
 - software: 1.0.19
 via_devices: null

--- a/devices/august/card-access-inc/md-05/info.yaml
+++ b/devices/august/card-access-inc/md-05/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Card Access Inc.
 manufacturer_raw: Card Access Inc.
 model_name: MD-05
 model_raw: MD-05
+same_as: null
 versions:
 - software: 1.0.20
 via_devices: null

--- a/devices/awair/awair/awair-element/info.yaml
+++ b/devices/awair/awair/awair-element/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Awair
 manufacturer_raw: Awair
 model_name: Awair Element
 model_raw: Awair Element
+same_as: null
 versions:
 - software: 1.4.1
 via_devices: null

--- a/devices/bond/chungear-industrial-co-ltd/mr196w/info.yaml
+++ b/devices/bond/chungear-industrial-co-ltd/mr196w/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Chungear Industrial Co., Ltd.
 manufacturer_raw: Chungear Industrial Co., Ltd.
 model_name: MR196W
 model_raw: MR196W
+same_as: null
 versions:
 - software: v3.5-beta
 via_devices: null

--- a/devices/bond/hinkley/900172/info.yaml
+++ b/devices/bond/hinkley/900172/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hinkley
 manufacturer_raw: Hinkley
 model_name: '900172'
 model_raw: '900172'
+same_as: null
 versions:
 - software: v3.5
 via_devices: null

--- a/devices/bond/hinkley/900982/info.yaml
+++ b/devices/bond/hinkley/900982/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hinkley
 manufacturer_raw: Hinkley
 model_name: '900982'
 model_raw: '900982'
+same_as: null
 versions:
 - software: v3.5-beta
 - software: v3.5

--- a/devices/bond/minka-aire/f467l/info.yaml
+++ b/devices/bond/minka-aire/f467l/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Minka Aire
 manufacturer_raw: Minka Aire
 model_name: F467L
 model_raw: F467L
+same_as: null
 versions:
 - software: v3.5
 via_devices: null

--- a/devices/bond/monte-carlo/mcsmrc/info.yaml
+++ b/devices/bond/monte-carlo/mcsmrc/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Monte Carlo
 manufacturer_raw: Monte Carlo
 model_name: MCSMRC
 model_raw: MCSMRC
+same_as: null
 versions:
 - software: v3.5
 via_devices: null

--- a/devices/bond/olibra/a1/info.yaml
+++ b/devices/bond/olibra/a1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Olibra
 manufacturer_raw: Olibra
 model_name: A1
 model_raw: A1
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/bond/olibra/a3a/info.yaml
+++ b/devices/bond/olibra/a3a/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Olibra
 manufacturer_raw: Olibra
 model_name: A3a
 model_raw: A3a
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/bond/olibra/c2/info.yaml
+++ b/devices/bond/olibra/c2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Olibra
 manufacturer_raw: Olibra
 model_name: C2
 model_raw: C2
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/bond/olibra/d1/info.yaml
+++ b/devices/bond/olibra/d1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Olibra
 manufacturer_raw: Olibra
 model_name: D1
 model_raw: D1
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/bond/olibra/somfy-rms12/info.yaml
+++ b/devices/bond/olibra/somfy-rms12/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Olibra
 manufacturer_raw: Olibra
 model_name: SOMFY RMS12
 model_raw: SOMFY RMS12
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/bond/progress-lighting/bf841/info.yaml
+++ b/devices/bond/progress-lighting/bf841/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Progress Lighting
 manufacturer_raw: Progress Lighting
 model_name: BF841
 model_raw: BF841
+same_as: null
 versions:
 - software: v2.13.0
 via_devices: null

--- a/devices/bond/progress-lighting/progress-generic-fan/info.yaml
+++ b/devices/bond/progress-lighting/progress-generic-fan/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Progress Lighting
 manufacturer_raw: Progress Lighting
 model_name: Progress Generic Fan
 model_raw: Progress Generic Fan
+same_as: null
 versions:
 - software: v3.5
 - software: v2.13.0

--- a/devices/bond/unbranded/mr196w/info.yaml
+++ b/devices/bond/unbranded/mr196w/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Unbranded
 manufacturer_raw: Unbranded
 model_name: MR196W
 model_raw: MR196W
+same_as: null
 versions:
 - software: v3.5-beta
 via_devices: null

--- a/devices/broadlink/broadlink/rm-mini-3/info.yaml
+++ b/devices/broadlink/broadlink/rm-mini-3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Broadlink
 manufacturer_raw: Broadlink
 model_name: RM mini 3
 model_raw: RM mini 3
+same_as: null
 versions:
 - software: '50'
 via_devices: null

--- a/devices/broadlink/broadlink/rm4-mini/info.yaml
+++ b/devices/broadlink/broadlink/rm4-mini/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Broadlink
 manufacturer_raw: Broadlink
 model_name: RM4 mini
 model_raw: RM4 mini
+same_as: null
 versions:
 - software: '62092'
 via_devices: null

--- a/devices/broadlink/broadlink/rm4-pro/info.yaml
+++ b/devices/broadlink/broadlink/rm4-pro/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Broadlink
 manufacturer_raw: Broadlink
 model_name: RM4 pro
 model_raw: RM4 pro
+same_as: null
 versions:
 - software: '62093'
 - software: '52079'

--- a/devices/brother/brother/hl-2270dw/info.yaml
+++ b/devices/brother/brother/hl-2270dw/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Brother
 manufacturer_raw: Brother
 model_name: HL-2270DW
 model_raw: HL-2270DW
+same_as: null
 versions:
 - software: '1.19'
 via_devices: null

--- a/devices/brother/brother/hl-l2325dw/info.yaml
+++ b/devices/brother/brother/hl-l2325dw/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Brother
 manufacturer_raw: Brother
 model_name: HL-L2325DW
 model_raw: HL-L2325DW
+same_as: null
 versions:
 - software: '1.58'
 via_devices: null

--- a/devices/cast/google-inc/chromecast-ultra/info.yaml
+++ b/devices/cast/google-inc/chromecast-ultra/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Chromecast Ultra
 model_raw: Chromecast Ultra
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/chromecast/info.yaml
+++ b/devices/cast/google-inc/chromecast/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Chromecast
 model_raw: Chromecast
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-cast-group/info.yaml
+++ b/devices/cast/google-inc/google-cast-group/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Cast Group
 model_raw: Google Cast Group
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-home-mini/info.yaml
+++ b/devices/cast/google-inc/google-home-mini/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Home Mini
 model_raw: Google Home Mini
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-home/info.yaml
+++ b/devices/cast/google-inc/google-home/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Home
 model_raw: Google Home
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-nest-hub-max/info.yaml
+++ b/devices/cast/google-inc/google-nest-hub-max/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Nest Hub Max
 model_raw: Google Nest Hub Max
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-nest-hub/info.yaml
+++ b/devices/cast/google-inc/google-nest-hub/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Nest Hub
 model_raw: Google Nest Hub
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/google-nest-mini/info.yaml
+++ b/devices/cast/google-inc/google-nest-mini/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Google Nest Mini
 model_raw: Google Nest Mini
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/google-inc/nest-audio/info.yaml
+++ b/devices/cast/google-inc/nest-audio/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Inc.
 manufacturer_raw: Google Inc.
 model_name: Nest Audio
 model_raw: Nest Audio
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/hisense/smarttv-4k/info.yaml
+++ b/devices/cast/hisense/smarttv-4k/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hisense
 manufacturer_raw: Hisense
 model_name: SmartTV 4K
 model_raw: SmartTV 4K
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/linkplay-technology-inc/wiim-pro-receiver/info.yaml
+++ b/devices/cast/linkplay-technology-inc/wiim-pro-receiver/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Linkplay Technology Inc
 manufacturer_raw: Linkplay Technology Inc
 model_name: WiiM Pro Receiver
 model_raw: WiiM Pro Receiver
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/nvidia/shield-android-tv/info.yaml
+++ b/devices/cast/nvidia/shield-android-tv/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: NVIDIA
 manufacturer_raw: NVIDIA
 model_name: SHIELD Android TV
 model_raw: SHIELD Android TV
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/sony/bravia-4k-gb-atv3/info.yaml
+++ b/devices/cast/sony/bravia-4k-gb-atv3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sony
 manufacturer_raw: Sony
 model_name: BRAVIA 4K GB ATV3
 model_raw: BRAVIA 4K GB ATV3
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/tpv/2021-22-philips-uhd-android-tv/info.yaml
+++ b/devices/cast/tpv/2021-22-philips-uhd-android-tv/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TPV
 manufacturer_raw: TPV
 model_name: 2021/22 Philips UHD Android TV
 model_raw: 2021/22 Philips UHD Android TV
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/unknown-manufacturer/hk-citation-multibeam-1100/info.yaml
+++ b/devices/cast/unknown-manufacturer/hk-citation-multibeam-1100/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Unknown manufacturer
 manufacturer_raw: Unknown manufacturer
 model_name: HK Citation MultiBeam 1100
 model_raw: HK Citation MultiBeam 1100
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/cast/xgimi/xk03h/info.yaml
+++ b/devices/cast/xgimi/xk03h/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: XGIMI
 manufacturer_raw: XGIMI
 model_name: XK03H
 model_raw: XK03H
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/denonavr/marantz/marantz-nr1711/info.yaml
+++ b/devices/denonavr/marantz/marantz-nr1711/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Marantz
 manufacturer_raw: Marantz
 model_name: Marantz NR1711
 model_raw: Marantz NR1711
+same_as: null
 versions:
 - hardware: avr-x-2016
 via_devices: null

--- a/devices/dlna_dmr/amazon/airscreen-mediarenderer/info.yaml
+++ b/devices/dlna_dmr/amazon/airscreen-mediarenderer/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: AirScreen MediaRenderer
 model_raw: AirScreen MediaRenderer
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/dlna_dmr/microsoft-corporation/windows-digital-media-renderer/info.yaml
+++ b/devices/dlna_dmr/microsoft-corporation/windows-digital-media-renderer/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Microsoft Corporation
 manufacturer_raw: Microsoft Corporation
 model_name: Windows Digital Media Renderer
 model_raw: Windows Digital Media Renderer
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/ecobee/ecobee/ecobee-room-sensor/info.yaml
+++ b/devices/ecobee/ecobee/ecobee-room-sensor/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ecobee
 manufacturer_raw: ecobee
 model_name: ecobee Room Sensor
 model_raw: ecobee Room Sensor
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/ecobee/ecobee/ecobee3-smart-thermostat/info.yaml
+++ b/devices/ecobee/ecobee/ecobee3-smart-thermostat/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ecobee
 manufacturer_raw: ecobee
 model_name: ecobee3 Smart Thermostat
 model_raw: ecobee3 Smart Thermostat
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/ecovacs/ecovacs/deebot-n8-pro/info.yaml
+++ b/devices/ecovacs/ecovacs/deebot-n8-pro/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ecovacs
 manufacturer_raw: Ecovacs
 model_name: DEEBOT N8 PRO
 model_raw: DEEBOT N8 PRO
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/elgato/elgato/elgato-key-light-air/info.yaml
+++ b/devices/elgato/elgato/elgato-key-light-air/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Elgato
 manufacturer_raw: Elgato
 model_name: Elgato Key Light Air
 model_raw: Elgato Key Light Air
+same_as: null
 versions:
 - hardware: '200'
   software: 1.0.3 (214)

--- a/devices/elkm1/elk-products-inc/m1/info.yaml
+++ b/devices/elkm1/elk-products-inc/m1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ELK Products, Inc.
 manufacturer_raw: ELK Products, Inc.
 model_name: M1
 model_raw: M1
+same_as: null
 versions:
 - software: 5.3.10
 via_devices: null

--- a/devices/enphase_envoy/enphase/envoy-phases-1-phase-mode-three-net-consumption-ct-production-ct/info.yaml
+++ b/devices/enphase_envoy/enphase/envoy-phases-1-phase-mode-three-net-consumption-ct-production-ct/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Enphase
 manufacturer_raw: Enphase
 model_name: 'Envoy, phases: 1, phase mode: three, net-consumption CT, production CT'
 model_raw: 'Envoy, phases: 1, phase mode: three, net-consumption CT, production CT'
+same_as: null
 versions:
 - hardware: 800-00654-r08
   software: 7.6.175

--- a/devices/enphase_envoy/enphase/envoy-phases-2-phase-mode-split-net-consumption-ct-production-ct/info.yaml
+++ b/devices/enphase_envoy/enphase/envoy-phases-2-phase-mode-split-net-consumption-ct-production-ct/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Enphase
 manufacturer_raw: Enphase
 model_name: 'Envoy, phases: 2, phase mode: split, net-consumption CT, production CT'
 model_raw: 'Envoy, phases: 2, phase mode: split, net-consumption CT, production CT'
+same_as: null
 versions:
 - hardware: 800-00555-r03
   software: 7.3.621

--- a/devices/enphase_envoy/enphase/envoy/info.yaml
+++ b/devices/enphase_envoy/enphase/envoy/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Enphase
 manufacturer_raw: Enphase
 model_name: Envoy
 model_raw: Envoy
+same_as: null
 versions:
 - hardware: 800-00069-r05
   software: 3.18.10

--- a/devices/enphase_envoy/enphase/inverter/info.yaml
+++ b/devices/enphase_envoy/enphase/inverter/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Enphase
 manufacturer_raw: Enphase
 model_name: Inverter
 model_raw: Inverter
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/flume/flume-inc/flume-smart-water-monitor/info.yaml
+++ b/devices/flume/flume-inc/flume-smart-water-monitor/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Flume, Inc.
 manufacturer_raw: Flume, Inc.
 model_name: Flume Smart Water Monitor
 model_raw: Flume Smart Water Monitor
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/flux_led/zengge/addressable-v3-5v-0xa3/info.yaml
+++ b/devices/flux_led/zengge/addressable-v3-5v-0xa3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zengge
 manufacturer_raw: Zengge
 model_name: Addressable v3 5v (0xA3)
 model_raw: Addressable v3 5v (0xA3)
+same_as: null
 versions:
 - hardware: AK001-ZJ2148
   software: '1.27'

--- a/devices/flux_led/zengge/controller-dimmable-0x41/info.yaml
+++ b/devices/flux_led/zengge/controller-dimmable-0x41/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zengge
 manufacturer_raw: Zengge
 model_name: Controller Dimmable (0x41)
 model_raw: Controller Dimmable (0x41)
+same_as: null
 versions:
 - hardware: AK001-ZJ21410
   software: '3.27'

--- a/devices/flux_led/zengge/controller-rgb-ir-0x33/info.yaml
+++ b/devices/flux_led/zengge/controller-rgb-ir-0x33/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zengge
 manufacturer_raw: Zengge
 model_name: Controller RGB IR (0x33)
 model_raw: Controller RGB IR (0x33)
+same_as: null
 versions:
 - hardware: AK001-ZJ210
   software: '6.37'

--- a/devices/fritzbox/avm/fritz-dect-200/info.yaml
+++ b/devices/fritzbox/avm/fritz-dect-200/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: FRITZ!DECT 200
 model_raw: FRITZ!DECT 200
+same_as: null
 versions:
 - software: '04.26'
 via_devices: null

--- a/devices/fritzbox/avm/fritz-dect-210/info.yaml
+++ b/devices/fritzbox/avm/fritz-dect-210/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: FRITZ!DECT 210
 model_raw: FRITZ!DECT 210
+same_as: null
 versions:
 - software: '04.25'
 via_devices: null

--- a/devices/fritzbox/avm/fritz-dect-440/info.yaml
+++ b/devices/fritzbox/avm/fritz-dect-440/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: FRITZ!DECT 440
 model_raw: FRITZ!DECT 440
+same_as: null
 versions:
 - software: '05.32'
 via_devices: null

--- a/devices/fritzbox/avm/smarthome-template/info.yaml
+++ b/devices/fritzbox/avm/smarthome-template/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: SmartHome Template
 model_raw: SmartHome Template
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/fritzbox_callmonitor/avm/fritz-box-7590-ax/info.yaml
+++ b/devices/fritzbox_callmonitor/avm/fritz-box-7590-ax/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: FRITZ!Box 7590 AX
 model_raw: FRITZ!Box 7590 AX
+same_as: null
 versions:
 - software: '7.81'
 via_devices: null

--- a/devices/fully_kiosk/amazon/kfmawi/info.yaml
+++ b/devices/fully_kiosk/amazon/kfmawi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: KFMAWI
 model_raw: KFMAWI
+same_as: null
 versions:
 - software: 1.48.2
 via_devices: null

--- a/devices/fully_kiosk/amazon/kfquwi/info.yaml
+++ b/devices/fully_kiosk/amazon/kfquwi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: KFQUWI
 model_raw: KFQUWI
+same_as: null
 versions:
 - software: 1.55.3-play
 via_devices: null

--- a/devices/govee_light_local/govee/h70c1/info.yaml
+++ b/devices/govee_light_local/govee/h70c1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Govee
 manufacturer_raw: Govee
 model_name: H70C1
 model_raw: H70C1
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/guardian/elexa/27-0-1-production-1af7b6d/info.yaml
+++ b/devices/guardian/elexa/27-0-1-production-1af7b6d/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Elexa
 manufacturer_raw: Elexa
 model_name: 27.0.1-production.1af7b6d
 model_raw: 27.0.1-production.1af7b6d
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/guardian/elexa/gld1/info.yaml
+++ b/devices/guardian/elexa/gld1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Elexa
 manufacturer_raw: Elexa
 model_name: gld1
 model_raw: gld1
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/harmony/logitech/harmony-hub/info.yaml
+++ b/devices/harmony/logitech/harmony-hub/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Logitech
 manufacturer_raw: Logitech
 model_name: Harmony Hub
 model_raw: Harmony Hub
+same_as: null
 versions:
 - software: 4.15.330
 - software: 10.0.215

--- a/devices/heos/heos/denon-ceol/info.yaml
+++ b/devices/heos/heos/denon-ceol/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: HEOS
 manufacturer_raw: HEOS
 model_name: Denon CEOL
 model_raw: Denon CEOL
+same_as: null
 versions:
 - software: 3.19.350
 via_devices: null

--- a/devices/homewizard/homewizard/hwe-wtr/info.yaml
+++ b/devices/homewizard/homewizard/hwe-wtr/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: HomeWizard
 manufacturer_raw: HomeWizard
 model_name: HWE-WTR
 model_raw: HWE-WTR
+same_as: null
 versions:
 - software: '3.01'
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/bsb002/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/bsb002/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: BSB002
 model_raw: BSB002
+same_as: null
 versions:
 - software: 1.64.1964117020
 - software: 1.65.1965017030

--- a/devices/hue/signify-netherlands-b-v/hue-ambiance-lamp-lta010/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-ambiance-lamp-lta010/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue ambiance lamp (LTA010)
 model_raw: Hue ambiance lamp (LTA010)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-ambiance-spot-ltg002/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-ambiance-spot-ltg002/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue ambiance spot (LTG002)
 model_raw: Hue ambiance spot (LTG002)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-color-candle-lct012/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-color-candle-lct012/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue color candle (LCT012)
 model_raw: Hue color candle (LCT012)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-color-lamp-lca001/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-color-lamp-lca001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue color lamp (LCA001)
 model_raw: Hue color lamp (LCA001)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-color-lamp-lca008/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-color-lamp-lca008/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue color lamp (LCA008)
 model_raw: Hue color lamp (LCA008)
+same_as: null
 versions:
 - software: 1.104.2
 - software: 1.116.3

--- a/devices/hue/signify-netherlands-b-v/hue-dimmer-switch-rwl021/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-dimmer-switch-rwl021/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue dimmer switch (RWL021)
 model_raw: Hue dimmer switch (RWL021)
+same_as: null
 versions:
 - software: 1.1.28573
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-dimmer-switch-rwl022/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-dimmer-switch-rwl022/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue dimmer switch (RWL022)
 model_raw: Hue dimmer switch (RWL022)
+same_as: null
 versions:
 - software: 2.45.2
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-lightstrip-plus-lcl001/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-lightstrip-plus-lcl001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue lightstrip plus (LCL001)
 model_raw: Hue lightstrip plus (LCL001)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-motion-sensor-sml001/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-motion-sensor-sml001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue motion sensor (SML001)
 model_raw: Hue motion sensor (SML001)
+same_as: null
 versions:
 - software: 1.1.27575
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-play-440400982841/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-play-440400982841/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue Play (440400982841)
 model_raw: Hue Play (440400982841)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-play-440400982842/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-play-440400982842/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue Play (440400982842)
 model_raw: Hue Play (440400982842)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-smart-button-rom001/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-smart-button-rom001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue Smart button (ROM001)
 model_raw: Hue Smart button (ROM001)
+same_as: null
 versions:
 - software: 2.47.8
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-smart-plug-lom007/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-smart-plug-lom007/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue smart plug (LOM007)
 model_raw: Hue smart plug (LOM007)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/hue-tap-dial-switch-rdm002/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/hue-tap-dial-switch-rdm002/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Hue tap dial switch (RDM002)
 model_raw: Hue tap dial switch (RDM002)
+same_as: null
 versions:
 - software: 2.59.25
 via_devices: null

--- a/devices/hue/signify-netherlands-b-v/signe-gradient-table-915005987001/info.yaml
+++ b/devices/hue/signify-netherlands-b-v/signe-gradient-table-915005987001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: Signe gradient table (915005987001)
 model_raw: Signe gradient table (915005987001)
+same_as: null
 versions:
 - software: 1.116.3
 via_devices: null

--- a/devices/hunterdouglas_powerview/hunter-douglas/duette-and-applause-skylift/info.yaml
+++ b/devices/hunterdouglas_powerview/hunter-douglas/duette-and-applause-skylift/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hunter Douglas
 manufacturer_raw: Hunter Douglas
 model_name: Duette and Applause SkyLift
 model_raw: Duette and Applause SkyLift
+same_as: null
 versions:
 - software: 1.8.1944
 via_devices: null

--- a/devices/hunterdouglas_powerview/hunter-douglas/powerview-generation-2/info.yaml
+++ b/devices/hunterdouglas_powerview/hunter-douglas/powerview-generation-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hunter Douglas
 manufacturer_raw: Hunter Douglas
 model_name: Powerview Generation 2
 model_raw: Powerview Generation 2
+same_as: null
 versions:
 - software: 2.0.1056
 via_devices: null

--- a/devices/hyperion/hyperion/hyperion-ng/info.yaml
+++ b/devices/hyperion/hyperion/hyperion-ng/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Hyperion
 manufacturer_raw: Hyperion
 model_name: Hyperion-NG
 model_raw: Hyperion-NG
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/ios/apple/ipad-mini-2/info.yaml
+++ b/devices/ios/apple/ipad-mini-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad Mini 2
 model_raw: iPad Mini 2
+same_as: null
 versions:
 - software: '11.4'
 via_devices: null

--- a/devices/ios/apple/ipad83/info.yaml
+++ b/devices/ios/apple/ipad83/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad8,3
 model_raw: iPad8,3
+same_as: null
 versions:
 - software: 13.2.2
 via_devices: null

--- a/devices/ios/apple/iphone125/info.yaml
+++ b/devices/ios/apple/iphone125/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone12,5
 model_raw: iPhone12,5
+same_as: null
 versions:
 - software: 13.2.3
 - software: 13.1.3

--- a/devices/lacrosse_view/lacrosse-technology/ltv-wsdth04/info.yaml
+++ b/devices/lacrosse_view/lacrosse-technology/ltv-wsdth04/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LaCrosse Technology
 manufacturer_raw: LaCrosse Technology
 model_name: LTV-WSDTH04
 model_raw: LTV-WSDTH04
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lacrosse_view/lacrosse-technology/rain-2-0-sensor/info.yaml
+++ b/devices/lacrosse_view/lacrosse-technology/rain-2-0-sensor/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LaCrosse Technology
 manufacturer_raw: LaCrosse Technology
 model_name: Rain 2.0 Sensor
 model_raw: Rain 2.0 Sensor
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lacrosse_view/lacrosse-technology/weather-station-display/info.yaml
+++ b/devices/lacrosse_view/lacrosse-technology/weather-station-display/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LaCrosse Technology
 manufacturer_raw: LaCrosse Technology
 model_name: Weather Station Display
 model_raw: Weather Station Display
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lifx/lifx/lifx-a19-night-vision/info.yaml
+++ b/devices/lifx/lifx/lifx-a19-night-vision/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX A19 Night Vision
 model_raw: LIFX A19 Night Vision
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-a21-1600lm-us/info.yaml
+++ b/devices/lifx/lifx/lifx-a21-1600lm-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX A21 1600lm US
 model_raw: LIFX A21 1600lm US
+same_as: null
 versions:
 - software: '4.3'
 via_devices: null

--- a/devices/lifx/lifx/lifx-beam/info.yaml
+++ b/devices/lifx/lifx/lifx-beam/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Beam
 model_raw: LIFX Beam
+same_as: null
 versions:
 - software: '2.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-br30-night-vision-intl/info.yaml
+++ b/devices/lifx/lifx/lifx-br30-night-vision-intl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX BR30 Night Vision Intl
 model_raw: LIFX BR30 Night Vision Intl
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-br30-night-vision/info.yaml
+++ b/devices/lifx/lifx/lifx-br30-night-vision/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX BR30 Night Vision
 model_raw: LIFX BR30 Night Vision
+same_as: null
 versions:
 - software: '2.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-clean/info.yaml
+++ b/devices/lifx/lifx/lifx-clean/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Clean
 model_raw: LIFX Clean
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-color/info.yaml
+++ b/devices/lifx/lifx/lifx-color/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Color
 model_raw: LIFX Color
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-downlight-intl/info.yaml
+++ b/devices/lifx/lifx/lifx-downlight-intl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Downlight Intl
 model_raw: LIFX Downlight Intl
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-filament-clear/info.yaml
+++ b/devices/lifx/lifx/lifx-filament-clear/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Filament Clear
 model_raw: LIFX Filament Clear
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-gu10/info.yaml
+++ b/devices/lifx/lifx/lifx-gu10/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX GU10
 model_raw: LIFX GU10
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-mini-color/info.yaml
+++ b/devices/lifx/lifx/lifx-mini-color/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Mini Color
 model_raw: LIFX Mini Color
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-mini-white-to-warm/info.yaml
+++ b/devices/lifx/lifx/lifx-mini-white-to-warm/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Mini White to Warm
 model_raw: LIFX Mini White to Warm
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-mini-white/info.yaml
+++ b/devices/lifx/lifx/lifx-mini-white/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Mini White
 model_raw: LIFX Mini White
+same_as: null
 versions:
 - software: '3.90'
 via_devices: null

--- a/devices/lifx/lifx/lifx-neon-intl/info.yaml
+++ b/devices/lifx/lifx/lifx-neon-intl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Neon Intl
 model_raw: LIFX Neon Intl
+same_as: null
 versions:
 - software: '3.100'
 via_devices: null

--- a/devices/lifx/lifx/lifx-outdoor-neon-us/info.yaml
+++ b/devices/lifx/lifx/lifx-outdoor-neon-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Outdoor Neon US
 model_raw: LIFX Outdoor Neon US
+same_as: null
 versions:
 - software: '4.3'
 via_devices: null

--- a/devices/lifx/lifx/lifx-round-path-us/info.yaml
+++ b/devices/lifx/lifx/lifx-round-path-us/info.yaml
@@ -7,6 +7,10 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Round Path US
 model_raw: LIFX Round Path US
+same_as:
+- integration: matter
+  manufacturer: LIFX
+  model: LIFX Path (Round)
 versions:
 - software: '4.3'
 via_devices: null

--- a/devices/lifx/lifx/lifx-round-spot-us/info.yaml
+++ b/devices/lifx/lifx/lifx-round-spot-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Round Spot US
 model_raw: LIFX Round Spot US
+same_as: null
 versions:
 - software: '4.3'
 via_devices: null

--- a/devices/lifx/lifx/lifx-square-path-us/info.yaml
+++ b/devices/lifx/lifx/lifx-square-path-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Square Path US
 model_raw: LIFX Square Path US
+same_as: null
 versions:
 - software: '4.3'
 via_devices: null

--- a/devices/lifx/lifx/lifx-string-intl/info.yaml
+++ b/devices/lifx/lifx/lifx-string-intl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX String Intl
 model_raw: LIFX String Intl
+same_as: null
 versions:
 - software: '3.100'
 via_devices: null

--- a/devices/lifx/lifx/lifx-tile/info.yaml
+++ b/devices/lifx/lifx/lifx-tile/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Tile
 model_raw: LIFX Tile
+same_as: null
 versions:
 - software: '3.50'
 via_devices: null

--- a/devices/lifx/lifx/lifx-z/info.yaml
+++ b/devices/lifx/lifx/lifx-z/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Z
 model_raw: LIFX Z
+same_as: null
 versions:
 - software: '2.90'
 via_devices: null

--- a/devices/lookin/lookin/lookin-remote2/info.yaml
+++ b/devices/lookin/lookin/lookin-remote2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LOOKin
 manufacturer_raw: LOOKin
 model_name: LOOKin Remote2
 model_raw: LOOKin Remote2
+same_as: null
 versions:
 - software: 2.43.0104
 - software: 2.43.0067

--- a/devices/lutron_caseta/lutron-electronics-co-inc/pj2-3brl-gxx-f01-pico3buttonraiselower/info.yaml
+++ b/devices/lutron_caseta/lutron-electronics-co-inc/pj2-3brl-gxx-f01-pico3buttonraiselower/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron Electronics Co., Inc
 manufacturer_raw: Lutron Electronics Co., Inc
 model_name: PJ2-3BRL-GXX-F01 (Pico3ButtonRaiseLower)
 model_raw: PJ2-3BRL-GXX-F01 (Pico3ButtonRaiseLower)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lutron_caseta/lutron-electronics-co-inc/pj2-3brl-gxx-x01-pico3buttonraiselower/info.yaml
+++ b/devices/lutron_caseta/lutron-electronics-co-inc/pj2-3brl-gxx-x01-pico3buttonraiselower/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron Electronics Co., Inc
 manufacturer_raw: Lutron Electronics Co., Inc
 model_name: PJ2-3BRL-GXX-X01 (Pico3ButtonRaiseLower)
 model_raw: PJ2-3BRL-GXX-X01 (Pico3ButtonRaiseLower)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lutron_caseta/lutron-electronics-co-inc/pj2-4b-gxx-x21-pico4button2group/info.yaml
+++ b/devices/lutron_caseta/lutron-electronics-co-inc/pj2-4b-gxx-x21-pico4button2group/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron Electronics Co., Inc
 manufacturer_raw: Lutron Electronics Co., Inc
 model_name: PJ2-4B-GXX-X21 (Pico4Button2Group)
 model_raw: PJ2-4B-GXX-X21 (Pico4Button2Group)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lutron_caseta/lutron-electronics-co-inc/qsyc-j-rcvr-qswirelessshade/info.yaml
+++ b/devices/lutron_caseta/lutron-electronics-co-inc/qsyc-j-rcvr-qswirelessshade/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron Electronics Co., Inc
 manufacturer_raw: Lutron Electronics Co., Inc
 model_name: QSYC-J-RCVR (QsWirelessShade)
 model_raw: QSYC-J-RCVR (QsWirelessShade)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/lutron_caseta/lutron-electronics-co-inc/rr-sel-rep-xx-ra2selectmainrepeater/info.yaml
+++ b/devices/lutron_caseta/lutron-electronics-co-inc/rr-sel-rep-xx-ra2selectmainrepeater/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron Electronics Co., Inc
 manufacturer_raw: Lutron Electronics Co., Inc
 model_name: RR-SEL-REP-XX (RA2SelectMainRepeater)
 model_raw: RR-SEL-REP-XX (RA2SelectMainRepeater)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/matter/eve-systems/eve-motionblinds-20caa9901/info.yaml
+++ b/devices/matter/eve-systems/eve-motionblinds-20caa9901/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Eve Systems
 manufacturer_raw: Eve Systems
 model_name: Eve MotionBlinds 20CAA9901
 model_raw: Eve MotionBlinds 20CAA9901
+same_as: null
 versions:
 - hardware: '1.1'
   software: 3.2.1

--- a/devices/matter/leedarson/smart-rgbtw-bulb/info.yaml
+++ b/devices/matter/leedarson/smart-rgbtw-bulb/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Leedarson
 manufacturer_raw: Leedarson
 model_name: Smart RGBTW Bulb
 model_raw: Smart RGBTW Bulb
+same_as: null
 versions:
 - hardware: 1.0.0
   software: 1.00.00

--- a/devices/matter/lifx/lifx-a21-1600/info.yaml
+++ b/devices/matter/lifx/lifx-a21-1600/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX A21 1600
 model_raw: LIFX A21 1600
+same_as: null
 versions:
 - hardware: '1'
   software: '4.03'

--- a/devices/matter/lifx/lifx-ceiling/info.yaml
+++ b/devices/matter/lifx/lifx-ceiling/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Ceiling
 model_raw: LIFX Ceiling
+same_as: null
 versions:
 - hardware: '1'
   software: '4.05'

--- a/devices/matter/lifx/lifx-path-round/info.yaml
+++ b/devices/matter/lifx/lifx-path-round/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Path (Round)
 model_raw: LIFX Path (Round)
+same_as: null
 versions:
 - hardware: '1'
   software: '4.03'

--- a/devices/matter/lifx/lifx-spot/info.yaml
+++ b/devices/matter/lifx/lifx-spot/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LIFX
 manufacturer_raw: LIFX
 model_name: LIFX Spot
 model_raw: LIFX Spot
+same_as: null
 versions:
 - hardware: '1'
   software: '4.03'

--- a/devices/matter/sengled/w41-n15a/info.yaml
+++ b/devices/matter/sengled/w41-n15a/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sengled
 manufacturer_raw: Sengled
 model_name: W41-N15A
 model_raw: W41-N15A
+same_as: null
 versions:
 - hardware: V1
   software: V1.0.0.5

--- a/devices/matter/sonoff/sonoff-switchman-wall-switch/info.yaml
+++ b/devices/matter/sonoff/sonoff-switchman-wall-switch/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: SONOFF
 manufacturer_raw: SONOFF
 model_name: SONOFF SwitchMan Wall Switch
 model_raw: SONOFF SwitchMan Wall Switch
+same_as: null
 versions:
 - hardware: '1.0'
   software: '1.0'

--- a/devices/matter/tp-link/mini-smart-wi-fi-plug/info.yaml
+++ b/devices/matter/tp-link/mini-smart-wi-fi-plug/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: Mini Smart Wi-Fi Plug
 model_raw: Mini Smart Wi-Fi Plug
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.0 Build 220930 Rel.143947

--- a/devices/mobile_app/amazon/kfmawi/info.yaml
+++ b/devices/mobile_app/amazon/kfmawi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: KFMAWI
 model_raw: KFMAWI
+same_as: null
 versions:
 - software: '28'
 via_devices: null

--- a/devices/mobile_app/amazon/kfquwi/info.yaml
+++ b/devices/mobile_app/amazon/kfquwi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: KFQUWI
 model_raw: KFQUWI
+same_as: null
 versions:
 - software: '30'
 via_devices: null

--- a/devices/mobile_app/amazon/kftrwi/info.yaml
+++ b/devices/mobile_app/amazon/kftrwi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Amazon
 manufacturer_raw: Amazon
 model_name: KFTRWI
 model_raw: KFTRWI
+same_as: null
 versions:
 - software: '28'
 via_devices: null

--- a/devices/mobile_app/apple/imac211/info.yaml
+++ b/devices/mobile_app/apple/imac211/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iMac21,1
 model_raw: iMac21,1
+same_as: null
 versions:
 - software: 14.5.0
 via_devices: null

--- a/devices/mobile_app/apple/ipad131/info.yaml
+++ b/devices/mobile_app/apple/ipad131/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad13,1
 model_raw: iPad13,1
+same_as: null
 versions:
 - software: 17.4.1
 via_devices: null

--- a/devices/mobile_app/apple/ipad1310/info.yaml
+++ b/devices/mobile_app/apple/ipad1310/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad13,10
 model_raw: iPad13,10
+same_as: null
 versions:
 - software: 17.5.1
 - software: 17.0.2

--- a/devices/mobile_app/apple/ipad134/info.yaml
+++ b/devices/mobile_app/apple/ipad134/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad13,4
 model_raw: iPad13,4
+same_as: null
 versions:
 - software: '17.4'
 - software: '18.0'

--- a/devices/mobile_app/apple/ipad136/info.yaml
+++ b/devices/mobile_app/apple/ipad136/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad13,6
 model_raw: iPad13,6
+same_as: null
 versions:
 - software: '18.0'
 via_devices: null

--- a/devices/mobile_app/apple/ipad138/info.yaml
+++ b/devices/mobile_app/apple/ipad138/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad13,8
 model_raw: iPad13,8
+same_as: null
 versions:
 - software: 15.6.1
 - software: 17.5.1

--- a/devices/mobile_app/apple/ipad148/info.yaml
+++ b/devices/mobile_app/apple/ipad148/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad14,8
 model_raw: iPad14,8
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/ipad44/info.yaml
+++ b/devices/mobile_app/apple/ipad44/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad4,4
 model_raw: iPad4,4
+same_as: null
 versions:
 - software: 12.5.7
 via_devices: null

--- a/devices/mobile_app/apple/ipad812/info.yaml
+++ b/devices/mobile_app/apple/ipad812/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPad8,12
 model_raw: iPad8,12
+same_as: null
 versions:
 - software: 17.4.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone/info.yaml
+++ b/devices/mobile_app/apple/iphone/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone
 model_raw: iPhone
+same_as: null
 versions:
 - software: iOS
 via_devices: null

--- a/devices/mobile_app/apple/iphone121/info.yaml
+++ b/devices/mobile_app/apple/iphone121/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone12,1
 model_raw: iPhone12,1
+same_as: null
 versions:
 - software: 17.3.1
 - software: 17.5.1

--- a/devices/mobile_app/apple/iphone128/info.yaml
+++ b/devices/mobile_app/apple/iphone128/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone12,8
 model_raw: iPhone12,8
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone132/info.yaml
+++ b/devices/mobile_app/apple/iphone132/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone13,2
 model_raw: iPhone13,2
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone133/info.yaml
+++ b/devices/mobile_app/apple/iphone133/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone13,3
 model_raw: iPhone13,3
+same_as: null
 versions:
 - software: 17.1.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone142/info.yaml
+++ b/devices/mobile_app/apple/iphone142/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone14,2
 model_raw: iPhone14,2
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone143/info.yaml
+++ b/devices/mobile_app/apple/iphone143/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone14,3
 model_raw: iPhone14,3
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone145/info.yaml
+++ b/devices/mobile_app/apple/iphone145/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone14,5
 model_raw: iPhone14,5
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone147/info.yaml
+++ b/devices/mobile_app/apple/iphone147/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone14,7
 model_raw: iPhone14,7
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone152/info.yaml
+++ b/devices/mobile_app/apple/iphone152/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone15,2
 model_raw: iPhone15,2
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone161/info.yaml
+++ b/devices/mobile_app/apple/iphone161/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone16,1
 model_raw: iPhone16,1
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/iphone162/info.yaml
+++ b/devices/mobile_app/apple/iphone162/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: iPhone16,2
 model_raw: iPhone16,2
+same_as: null
 versions:
 - software: 17.5.1
 via_devices: null

--- a/devices/mobile_app/apple/mac1412/info.yaml
+++ b/devices/mobile_app/apple/mac1412/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Mac14,12
 model_raw: Mac14,12
+same_as: null
 versions:
 - software: 13.5.1
 - software: 14.5.0

--- a/devices/mobile_app/apple/mac145/info.yaml
+++ b/devices/mobile_app/apple/mac145/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Mac14,5
 model_raw: Mac14,5
+same_as: null
 versions:
 - software: 14.5.0
 via_devices: null

--- a/devices/mobile_app/apple/macbookpro181/info.yaml
+++ b/devices/mobile_app/apple/macbookpro181/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: MacBookPro18,1
 model_raw: MacBookPro18,1
+same_as: null
 versions:
 - software: 14.5.0
 - software: 14.4.1

--- a/devices/mobile_app/google/chromecast/info.yaml
+++ b/devices/mobile_app/google/chromecast/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Chromecast
 model_raw: Chromecast
+same_as: null
 versions:
 - software: '31'
 via_devices: null

--- a/devices/mobile_app/google/google-pixel-watch-2/info.yaml
+++ b/devices/mobile_app/google/google-pixel-watch-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Google Pixel Watch 2
 model_raw: Google Pixel Watch 2
+same_as: null
 versions:
 - software: '33'
 via_devices: null

--- a/devices/mobile_app/google/google-pixel-watch/info.yaml
+++ b/devices/mobile_app/google/google-pixel-watch/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Google Pixel Watch
 model_raw: Google Pixel Watch
+same_as: null
 versions:
 - software: '30'
 via_devices: null

--- a/devices/mobile_app/google/kukui/info.yaml
+++ b/devices/mobile_app/google/kukui/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: kukui
 model_raw: kukui
+same_as: null
 versions:
 - software: '30'
 via_devices: null

--- a/devices/mobile_app/google/pixel-3/info.yaml
+++ b/devices/mobile_app/google/pixel-3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Pixel 3
 model_raw: Pixel 3
+same_as: null
 versions:
 - software: '31'
 via_devices: null

--- a/devices/mobile_app/google/pixel-7-pro/info.yaml
+++ b/devices/mobile_app/google/pixel-7-pro/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Pixel 7 Pro
 model_raw: Pixel 7 Pro
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/google/pixel-8/info.yaml
+++ b/devices/mobile_app/google/pixel-8/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google
 manufacturer_raw: Google
 model_name: Pixel 8
 model_raw: Pixel 8
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/lenovo/lenovo-tb-x306f/info.yaml
+++ b/devices/mobile_app/lenovo/lenovo-tb-x306f/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LENOVO
 manufacturer_raw: LENOVO
 model_name: Lenovo TB-X306F
 model_raw: Lenovo TB-X306F
+same_as: null
 versions:
 - software: '30'
 - software: '29'

--- a/devices/mobile_app/lenovo/lenovo-tb128xu/info.yaml
+++ b/devices/mobile_app/lenovo/lenovo-tb128xu/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LENOVO
 manufacturer_raw: LENOVO
 model_name: Lenovo TB128XU
 model_raw: Lenovo TB128XU
+same_as: null
 versions:
 - software: '33'
 via_devices: null

--- a/devices/mobile_app/microsoft/surface-duo/info.yaml
+++ b/devices/mobile_app/microsoft/surface-duo/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Microsoft
 manufacturer_raw: Microsoft
 model_name: Surface Duo
 model_raw: Surface Duo
+same_as: null
 versions:
 - software: '32'
 via_devices: null

--- a/devices/mobile_app/mobvoi/ticwatch-pro-5/info.yaml
+++ b/devices/mobile_app/mobvoi/ticwatch-pro-5/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Mobvoi
 manufacturer_raw: Mobvoi
 model_name: TicWatch Pro 5
 model_raw: TicWatch Pro 5
+same_as: null
 versions:
 - software: '30'
 via_devices: null

--- a/devices/mobile_app/motorola/motorola-edge-20-fusion/info.yaml
+++ b/devices/mobile_app/motorola/motorola-edge-20-fusion/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: motorola
 manufacturer_raw: motorola
 model_name: motorola edge 20 fusion
 model_raw: motorola edge 20 fusion
+same_as: null
 versions:
 - software: '31'
 via_devices: null

--- a/devices/mobile_app/nothing/a063/info.yaml
+++ b/devices/mobile_app/nothing/a063/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Nothing
 manufacturer_raw: Nothing
 model_name: A063
 model_raw: A063
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/oculus/quest/info.yaml
+++ b/devices/mobile_app/oculus/quest/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Oculus
 manufacturer_raw: Oculus
 model_name: Quest
 model_raw: Quest
+same_as: null
 versions:
 - software: '32'
 - software: '29'

--- a/devices/mobile_app/samsung/sm-a528b/info.yaml
+++ b/devices/mobile_app/samsung/sm-a528b/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-A528B
 model_raw: SM-A528B
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/samsung/sm-f731b/info.yaml
+++ b/devices/mobile_app/samsung/sm-f731b/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-F731B
 model_raw: SM-F731B
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/samsung/sm-g781b/info.yaml
+++ b/devices/mobile_app/samsung/sm-g781b/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-G781B
 model_raw: SM-G781B
+same_as: null
 versions:
 - software: '33'
 via_devices: null

--- a/devices/mobile_app/samsung/sm-g998b/info.yaml
+++ b/devices/mobile_app/samsung/sm-g998b/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-G998B
 model_raw: SM-G998B
+same_as: null
 versions:
 - software: '34'
 via_devices: null

--- a/devices/mobile_app/samsung/sm-n960f/info.yaml
+++ b/devices/mobile_app/samsung/sm-n960f/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-N960F
 model_raw: SM-N960F
+same_as: null
 versions:
 - software: '29'
 via_devices: null

--- a/devices/mobile_app/samsung/sm-p610/info.yaml
+++ b/devices/mobile_app/samsung/sm-p610/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: samsung
 manufacturer_raw: samsung
 model_name: SM-P610
 model_raw: SM-P610
+same_as: null
 versions:
 - software: '33'
 via_devices: null

--- a/devices/mobile_app/volvocars/polestar/info.yaml
+++ b/devices/mobile_app/volvocars/polestar/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VolvoCars
 manufacturer_raw: VolvoCars
 model_name: Polestar
 model_raw: Polestar
+same_as: null
 versions:
 - software: '30'
 via_devices: null

--- a/devices/mobile_app/xiaomi/redmi-note-9s/info.yaml
+++ b/devices/mobile_app/xiaomi/redmi-note-9s/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Xiaomi
 manufacturer_raw: Xiaomi
 model_name: Redmi Note 9S
 model_raw: Redmi Note 9S
+same_as: null
 versions:
 - software: '31'
 via_devices: null

--- a/devices/nanoleaf/nanoleaf/nl22/info.yaml
+++ b/devices/nanoleaf/nanoleaf/nl22/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Nanoleaf
 manufacturer_raw: Nanoleaf
 model_name: NL22
 model_raw: NL22
+same_as: null
 versions:
 - software: 5.2.2
 via_devices: null

--- a/devices/nest/google-nest/thermostat/info.yaml
+++ b/devices/nest/google-nest/thermostat/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Google Nest
 manufacturer_raw: Google Nest
 model_name: Thermostat
 model_raw: Thermostat
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nexia/trane/xl1050/info.yaml
+++ b/devices/nexia/trane/xl1050/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Trane
 manufacturer_raw: Trane
 model_name: XL1050
 model_raw: XL1050
+same_as: null
 versions:
 - software: 5.10.1
 via_devices: null

--- a/devices/nobo_hub/glen-dimplex-nordic-as/nobo-ecohub-11123618-rev-1/info.yaml
+++ b/devices/nobo_hub/glen-dimplex-nordic-as/nobo-ecohub-11123618-rev-1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Glen Dimplex Nordic AS
 manufacturer_raw: Glen Dimplex Nordic AS
 model_name: "Nob\xF8 Ecohub (11123618_rev._1)"
 model_raw: "Nob\xF8 Ecohub (11123618_rev._1)"
+same_as: null
 versions:
 - software: '114'
 via_devices: null

--- a/devices/nut/american-power-conversion/back-ups-rs-1500g/info.yaml
+++ b/devices/nut/american-power-conversion/back-ups-rs-1500g/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: American Power Conversion
 manufacturer_raw: American Power Conversion
 model_name: Back-UPS RS 1500G
 model_raw: Back-UPS RS 1500G
+same_as: null
 versions:
 - software: 865.L9 .D
 via_devices: null

--- a/devices/nut/american-power-conversion/back-ups-rs-900g/info.yaml
+++ b/devices/nut/american-power-conversion/back-ups-rs-900g/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: American Power Conversion
 manufacturer_raw: American Power Conversion
 model_name: Back-UPS RS 900G
 model_raw: Back-UPS RS 900G
+same_as: null
 versions:
 - software: 879.L4 .I
 via_devices: null

--- a/devices/nut/cps/cp1500avrlcda/info.yaml
+++ b/devices/nut/cps/cp1500avrlcda/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: CPS
 manufacturer_raw: CPS
 model_name: CP1500AVRLCDa
 model_raw: CP1500AVRLCDa
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nut/cps/cp1500pfclcda/info.yaml
+++ b/devices/nut/cps/cp1500pfclcda/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: CPS
 manufacturer_raw: CPS
 model_name: CP1500PFCLCDa
 model_raw: CP1500PFCLCDa
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nut/cps/cst135xlu/info.yaml
+++ b/devices/nut/cps/cst135xlu/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: CPS
 manufacturer_raw: CPS
 model_name: CST135XLU
 model_raw: CST135XLU
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nut/cps/or1500lcdrm1ua/info.yaml
+++ b/devices/nut/cps/or1500lcdrm1ua/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: CPS
 manufacturer_raw: CPS
 model_name: OR1500LCDRM1Ua
 model_raw: OR1500LCDRM1Ua
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nut/cps/pr3000rt2u/info.yaml
+++ b/devices/nut/cps/pr3000rt2u/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: CPS
 manufacturer_raw: CPS
 model_name: PR3000RT2U
 model_raw: PR3000RT2U
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/nut/eaton/5p-1550/info.yaml
+++ b/devices/nut/eaton/5p-1550/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: EATON
 manufacturer_raw: EATON
 model_name: 5P 1550
 model_raw: 5P 1550
+same_as: null
 versions:
 - software: 03.18.0035
 via_devices: null

--- a/devices/nut/eaton/ellipse-eco-800/info.yaml
+++ b/devices/nut/eaton/ellipse-eco-800/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: EATON
 manufacturer_raw: EATON
 model_name: Ellipse ECO 800
 model_raw: Ellipse ECO 800
+same_as: null
 versions:
 - software: '02'
 via_devices: null

--- a/devices/oncue/kohler/38-rclb/info.yaml
+++ b/devices/oncue/kohler/38-rclb/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Kohler
 manufacturer_raw: Kohler
 model_name: 38 RCLB
 model_raw: 38 RCLB
+same_as: null
 versions:
 - hardware: '604'
   software: 3.4.5

--- a/devices/onvif/d-link/dcs-8325lh/info.yaml
+++ b/devices/onvif/d-link/dcs-8325lh/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: D-Link
 manufacturer_raw: D-Link
 model_name: DCS-8325LH
 model_raw: DCS-8325LH
+same_as: null
 versions:
 - software: '1.05'
 via_devices: null

--- a/devices/onvif/dahua/dhi-nvr5208-8p-4ks2e/info.yaml
+++ b/devices/onvif/dahua/dhi-nvr5208-8p-4ks2e/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Dahua
 manufacturer_raw: Dahua
 model_name: DHI-NVR5208-8P-4KS2E
 model_raw: DHI-NVR5208-8P-4KS2E
+same_as: null
 versions:
 - software: 4.002.0000000.6.R, Build Date 2022-11-15
 via_devices: null

--- a/devices/onvif/h264/hi3516ev100-50h20l-s38/info.yaml
+++ b/devices/onvif/h264/hi3516ev100-50h20l-s38/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: H264
 manufacturer_raw: H264
 model_name: HI3516EV100_50H20L_S38
 model_raw: HI3516EV100_50H20L_S38
+same_as: null
 versions:
 - software: V4.02.R12.00035520.12012.043700..ONVIF 2.41
 via_devices: null

--- a/devices/onvif/hikvision/ds-2cd2020f-i/info.yaml
+++ b/devices/onvif/hikvision/ds-2cd2020f-i/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: HIKVISION
 manufacturer_raw: HIKVISION
 model_name: DS-2CD2020F-I
 model_raw: DS-2CD2020F-I
+same_as: null
 versions:
 - software: V5.4.800 build 210813
 via_devices: null

--- a/devices/onvif/hikvision/ds-2cd2046g2-i/info.yaml
+++ b/devices/onvif/hikvision/ds-2cd2046g2-i/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: HIKVISION
 manufacturer_raw: HIKVISION
 model_name: DS-2CD2046G2-I
 model_raw: DS-2CD2046G2-I
+same_as: null
 versions:
 - software: V5.7.14
 via_devices: null

--- a/devices/onvif/onvif-ipnc/f4g/info.yaml
+++ b/devices/onvif/onvif-ipnc/f4g/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ONVIF_IPNC
 manufacturer_raw: ONVIF_IPNC
 model_name: F4G
 model_raw: F4G
+same_as: null
 versions:
 - software: 2.1.0-20211214SG
 via_devices: null

--- a/devices/onvif/tp-link/c225/info.yaml
+++ b/devices/onvif/tp-link/c225/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: C225
 model_raw: C225
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.28 Build 231214 Rel.69164n

--- a/devices/overkiz/somfy/dimmerlight/info.yaml
+++ b/devices/overkiz/somfy/dimmerlight/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Somfy
 manufacturer_raw: Somfy
 model_name: DimmerLight
 model_raw: DimmerLight
+same_as: null
 versions:
 - hardware: io:DimmableLightIOComponent
   software: 5109156A09

--- a/devices/overkiz/somfy/positionablehorizontalawning/info.yaml
+++ b/devices/overkiz/somfy/positionablehorizontalawning/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Somfy
 manufacturer_raw: Somfy
 model_name: PositionableHorizontalAwning
 model_raw: PositionableHorizontalAwning
+same_as: null
 versions:
 - hardware: io:HorizontalAwningIOComponent
   software: 5104761X04

--- a/devices/overkiz/somfy/positionablescreen/info.yaml
+++ b/devices/overkiz/somfy/positionablescreen/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Somfy
 manufacturer_raw: Somfy
 model_name: PositionableScreen
 model_raw: PositionableScreen
+same_as: null
 versions:
 - hardware: io:VerticalExteriorAwningIOComponent
   software: 5118126A10

--- a/devices/panasonic_viera/panasonic/panasonic-viera/info.yaml
+++ b/devices/panasonic_viera/panasonic/panasonic-viera/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Panasonic
 manufacturer_raw: Panasonic
 model_name: Panasonic Viera
 model_raw: Panasonic Viera
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/philips_js/philips/48oled807-12/info.yaml
+++ b/devices/philips_js/philips/48oled807-12/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Philips
 manufacturer_raw: Philips
 model_name: 48OLED807/12
 model_raw: 48OLED807/12
+same_as: null
 versions:
 - software: TPM211EA_R.101.001.004.252
 via_devices: null

--- a/devices/plex/android/plex-for-android-mobile/info.yaml
+++ b/devices/plex/android/plex-for-android-mobile/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Android
 manufacturer_raw: Android
 model_name: Plex for Android (Mobile)
 model_raw: Plex for Android (Mobile)
+same_as: null
 versions:
 - software: 9.27.0.2856
 - software: 10.5.0.4996

--- a/devices/plex/android/plex-for-android-tv/info.yaml
+++ b/devices/plex/android/plex-for-android-tv/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Android
 manufacturer_raw: Android
 model_name: Plex for Android (TV)
 model_raw: Plex for Android (TV)
+same_as: null
 versions:
 - software: 9.26.1.2783
 - software: 9.20.1.979

--- a/devices/plex/chromecast/plex-cast/info.yaml
+++ b/devices/plex/chromecast/plex-cast/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Chromecast
 manufacturer_raw: Chromecast
 model_name: Plex Cast
 model_raw: Plex Cast
+same_as: null
 versions:
 - software: 4.54.1
 via_devices: null

--- a/devices/plex/ios/plex-for-ios/info.yaml
+++ b/devices/plex/ios/plex-for-ios/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iOS
 manufacturer_raw: iOS
 model_name: Plex for iOS
 model_raw: Plex for iOS
+same_as: null
 versions:
 - software: '8.23'
 - software: '8.18'

--- a/devices/plex/macos/plex-for-mac/info.yaml
+++ b/devices/plex/macos/plex-for-mac/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: macos
 manufacturer_raw: macos
 model_name: Plex for Mac
 model_raw: Plex for Mac
+same_as: null
 versions:
 - software: 1.87.2.87-87488d5a
 via_devices: null

--- a/devices/plex/plex/plex-media-server/info.yaml
+++ b/devices/plex/plex/plex-media-server/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Plex
 manufacturer_raw: Plex
 model_name: Plex Media Server
 model_raw: Plex Media Server
+same_as: null
 versions:
 - software: 1.40.0.7998-c29d4c0c8
 - software: 1.40.3.8555-fef15d30c

--- a/devices/plex/samsung/plex-for-samsung/info.yaml
+++ b/devices/plex/samsung/plex-for-samsung/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: Plex for Samsung
 model_raw: Plex for Samsung
+same_as: null
 versions:
 - software: '2.012'
 via_devices: null

--- a/devices/plex/tizen/plex-for-samsung/info.yaml
+++ b/devices/plex/tizen/plex-for-samsung/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tizen
 manufacturer_raw: Tizen
 model_name: Plex for Samsung
 model_raw: Plex for Samsung
+same_as: null
 versions:
 - software: 5.74.0
 - software: 5.59.3

--- a/devices/plex/tvos/plex-for-apple-tv/info.yaml
+++ b/devices/plex/tvos/plex-for-apple-tv/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: tvOS
 manufacturer_raw: tvOS
 model_name: Plex for Apple TV
 model_raw: Plex for Apple TV
+same_as: null
 versions:
 - software: '8.34'
 via_devices: null

--- a/devices/plex/webos/plex-for-lg/info.yaml
+++ b/devices/plex/webos/plex-for-lg/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: webOS
 manufacturer_raw: webOS
 model_name: Plex for LG
 model_raw: Plex for LG
+same_as: null
 versions:
 - software: 5.62.0
 via_devices: null

--- a/devices/plex/windows/plex-for-windows/info.yaml
+++ b/devices/plex/windows/plex-for-windows/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: windows
 manufacturer_raw: windows
 model_name: Plex for Windows
 model_raw: Plex for Windows
+same_as: null
 versions:
 - software: 1.77.3.3966-a5ddb215
 - software: 1.49.1.3146-73559c78

--- a/devices/powerwall/tesla/powerwall-2-1092170-03-j/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-1092170-03-j/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (1092170-03-J)
 model_raw: PowerWall 2 (1092170-03-J)
+same_as: null
 versions:
 - software: 23.28.2 27626f98
 via_devices: null

--- a/devices/powerwall/tesla/powerwall-2-1092170-05-j/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-1092170-05-j/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (1092170-05-J)
 model_raw: PowerWall 2 (1092170-05-J)
+same_as: null
 versions:
 - software: 23.36.3 aa269d35
 via_devices: null

--- a/devices/powerwall/tesla/powerwall-2-2012170-53-d/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-2012170-53-d/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (2012170-53-D)
 model_raw: PowerWall 2 (2012170-53-D)
+same_as: null
 versions:
 - software: 23.28.2 27626f98
 via_devices: null

--- a/devices/powerwall/tesla/powerwall-2-3012170-05-c/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-3012170-05-c/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (3012170-05-C)
 model_raw: PowerWall 2 (3012170-05-C)
+same_as: null
 versions:
 - software: 24.4.0 0fe780c9
 - software: 24.12.3 1feaff3a

--- a/devices/powerwall/tesla/powerwall-2-gw1/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-gw1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (GW1)
 model_raw: PowerWall 2 (GW1)
+same_as: null
 versions:
 - software: 23.28.2 27626f98
 - software: 23.36.3 aa269d35

--- a/devices/powerwall/tesla/powerwall-2-gw2/info.yaml
+++ b/devices/powerwall/tesla/powerwall-2-gw2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: PowerWall 2 (GW2)
 model_raw: PowerWall 2 (GW2)
+same_as: null
 versions:
 - software: 24.4.0 0fe780c9
 - software: 24.12.3 1feaff3a

--- a/devices/prosegur/prosegur/smart/info.yaml
+++ b/devices/prosegur/prosegur/smart/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Prosegur
 manufacturer_raw: Prosegur
 model_name: smart
 model_raw: smart
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/qnap/qnap/ts-251/info.yaml
+++ b/devices/qnap/qnap/ts-251/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: QNAP
 manufacturer_raw: QNAP
 model_name: TS-251+
 model_raw: TS-251+
+same_as: null
 versions:
 - software: 5.1.5
 via_devices: null

--- a/devices/rachio/rachio/generation2-8zone/info.yaml
+++ b/devices/rachio/rachio/generation2-8zone/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Rachio
 manufacturer_raw: Rachio
 model_name: GENERATION2_8ZONE
 model_raw: GENERATION2_8ZONE
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/rachio/rachio/generation3-16zone/info.yaml
+++ b/devices/rachio/rachio/generation3-16zone/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Rachio
 manufacturer_raw: Rachio
 model_name: GENERATION3_16ZONE
 model_raw: GENERATION3_16ZONE
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/rainmachine/rainmachine/version-3-api-4-6-1/info.yaml
+++ b/devices/rainmachine/rainmachine/version-3-api-4-6-1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: RainMachine
 manufacturer_raw: RainMachine
 model_name: 'Version 3 (API: 4.6.1)'
 model_raw: 'Version 3 (API: 4.6.1)'
+same_as: null
 versions:
 - software: 4.0.1144
 via_devices: null

--- a/devices/reolink/reolink/reolink-duo-floodlight-poe/info.yaml
+++ b/devices/reolink/reolink/reolink-duo-floodlight-poe/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: Reolink Duo Floodlight PoE
 model_raw: Reolink Duo Floodlight PoE
+same_as: null
 versions:
 - hardware: IPC_529B17B8MP
   software: v3.0.0.1889_23031702

--- a/devices/reolink/reolink/reolink-video-doorbell-poe/info.yaml
+++ b/devices/reolink/reolink/reolink-video-doorbell-poe/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: Reolink Video Doorbell PoE
 model_raw: Reolink Video Doorbell PoE
+same_as: null
 versions:
 - hardware: DB_566128M5MP_P
   software: v3.0.0.2555_23080702

--- a/devices/reolink/reolink/reolink-video-doorbell-wifi/info.yaml
+++ b/devices/reolink/reolink/reolink-video-doorbell-wifi/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: Reolink Video Doorbell WiFi
 model_raw: Reolink Video Doorbell WiFi
+same_as: null
 versions:
 - hardware: DB_566128M5MP_W
   software: v3.0.0.3215_2401262240

--- a/devices/reolink/reolink/rlc-410-5mp/info.yaml
+++ b/devices/reolink/reolink/rlc-410-5mp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: RLC-410-5MP
 model_raw: RLC-410-5MP
+same_as: null
 versions:
 - hardware: IPC_51516M5M
   software: v3.0.0.136_20121100

--- a/devices/reolink/reolink/rlc-510a/info.yaml
+++ b/devices/reolink/reolink/rlc-510a/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: RLC-510A
 model_raw: RLC-510A
+same_as: null
 versions:
 - hardware: IPC_MS1NA45MP
   software: v3.0.0.2417_23070500

--- a/devices/reolink/reolink/rlc-520/info.yaml
+++ b/devices/reolink/reolink/rlc-520/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: RLC-520
 model_raw: RLC-520
+same_as: null
 versions:
 - hardware: IPC_51516M5M
   software: v3.0.0.136_20121112

--- a/devices/reolink/reolink/rlc-820a/info.yaml
+++ b/devices/reolink/reolink/rlc-820a/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: RLC-820A
 model_raw: RLC-820A
+same_as: null
 versions:
 - hardware: IPC_523128M8MP
   software: v3.1.0.956_22041501

--- a/devices/reolink/reolink/rlc-830a/info.yaml
+++ b/devices/reolink/reolink/rlc-830a/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Reolink
 manufacturer_raw: Reolink
 model_name: RLC-830A
 model_raw: RLC-830A
+same_as: null
 versions:
 - hardware: IPC_560SD78MP
   software: v3.1.0.2515_23082406

--- a/devices/roborock/roborock/roborock-vacuum-a08/info.yaml
+++ b/devices/roborock/roborock/roborock-vacuum-a08/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Roborock
 manufacturer_raw: Roborock
 model_name: roborock.vacuum.a08
 model_raw: roborock.vacuum.a08
+same_as: null
 versions:
 - software: 02.13.68
 via_devices: null

--- a/devices/roborock/roborock/roborock-vacuum-a10/info.yaml
+++ b/devices/roborock/roborock/roborock-vacuum-a10/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Roborock
 manufacturer_raw: Roborock
 model_name: roborock.vacuum.a10
 model_raw: roborock.vacuum.a10
+same_as: null
 versions:
 - software: 02.62.46
 via_devices: null

--- a/devices/roborock/roborock/roborock-vacuum-a27/info.yaml
+++ b/devices/roborock/roborock/roborock-vacuum-a27/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Roborock
 manufacturer_raw: Roborock
 model_name: roborock.vacuum.a27
 model_raw: roborock.vacuum.a27
+same_as: null
 versions:
 - software: 02.58.40
 via_devices: null

--- a/devices/roku/roku/roku-ultra/info.yaml
+++ b/devices/roku/roku/roku-ultra/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Roku
 manufacturer_raw: Roku
 model_name: Roku Ultra
 model_raw: Roku Ultra
+same_as: null
 versions:
 - hardware: 4660RW
   software: 13.0.0

--- a/devices/roku/tcl/40s325/info.yaml
+++ b/devices/roku/tcl/40s325/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TCL
 manufacturer_raw: TCL
 model_name: 40S325
 model_raw: 40S325
+same_as: null
 versions:
 - hardware: 8113X
   software: 13.0.0

--- a/devices/roku/tcl/50s425/info.yaml
+++ b/devices/roku/tcl/50s425/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TCL
 manufacturer_raw: TCL
 model_name: 50S425
 model_raw: 50S425
+same_as: null
 versions:
 - hardware: C105X
   software: 13.0.0

--- a/devices/roomba/irobot/i115240/info.yaml
+++ b/devices/roomba/irobot/i115240/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iRobot
 manufacturer_raw: iRobot
 model_name: i115240
 model_raw: i115240
+same_as: null
 versions:
 - software: daredevil+2.6.0+daredevil-release+163
 via_devices: null

--- a/devices/roomba/irobot/m611020/info.yaml
+++ b/devices/roomba/irobot/m611020/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iRobot
 manufacturer_raw: iRobot
 model_name: m611020
 model_raw: m611020
+same_as: null
 versions:
 - software: sanmarino+22.29.6+2022-12-01-82f3372a65c+Firmware-Build+2321
 via_devices: null

--- a/devices/roomba/irobot/r692040/info.yaml
+++ b/devices/roomba/irobot/r692040/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iRobot
 manufacturer_raw: iRobot
 model_name: R692040
 model_raw: R692040
+same_as: null
 versions:
 - hardware: '9'
   software: 3.5.69+103

--- a/devices/roomba/irobot/r981040/info.yaml
+++ b/devices/roomba/irobot/r981040/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iRobot
 manufacturer_raw: iRobot
 model_name: R981040
 model_raw: R981040
+same_as: null
 versions:
 - hardware: '3'
   software: v2.4.17-138

--- a/devices/roomba/irobot/s955020/info.yaml
+++ b/devices/roomba/irobot/s955020/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: iRobot
 manufacturer_raw: iRobot
 model_name: s955020
 model_raw: s955020
+same_as: null
 versions:
 - software: soho+22.29.10+2023-10-09-2b3f87f75e8+Firmware-Build+4863
 via_devices: null

--- a/devices/samsungtv/samsung-electronics/un46d6000/info.yaml
+++ b/devices/samsungtv/samsung-electronics/un46d6000/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung Electronics
 manufacturer_raw: Samsung Electronics
 model_name: UN46D6000
 model_raw: UN46D6000
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung-electronics/un55ku630d/info.yaml
+++ b/devices/samsungtv/samsung-electronics/un55ku630d/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung Electronics
 manufacturer_raw: Samsung Electronics
 model_name: UN55KU630D
 model_raw: UN55KU630D
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung-electronics/un65ju6400/info.yaml
+++ b/devices/samsungtv/samsung-electronics/un65ju6400/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung Electronics
 manufacturer_raw: Samsung Electronics
 model_name: UN65JU6400
 model_raw: UN65JU6400
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/qa65q60bawxxy/info.yaml
+++ b/devices/samsungtv/samsung/qa65q60bawxxy/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: QA65Q60BAWXXY
 model_raw: QA65Q60BAWXXY
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/qn43ls03bafxza/info.yaml
+++ b/devices/samsungtv/samsung/qn43ls03bafxza/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: QN43LS03BAFXZA
 model_raw: QN43LS03BAFXZA
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/qn55q6daafxza/info.yaml
+++ b/devices/samsungtv/samsung/qn55q6daafxza/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: QN55Q6DAAFXZA
 model_raw: QN55Q6DAAFXZA
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/qn82q60rafxza/info.yaml
+++ b/devices/samsungtv/samsung/qn82q60rafxza/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: QN82Q60RAFXZA
 model_raw: QN82Q60RAFXZA
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/qn85qn85bdfxza/info.yaml
+++ b/devices/samsungtv/samsung/qn85qn85bdfxza/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: QN85QN85BDFXZA
 model_raw: QN85QN85BDFXZA
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/un55ku630d/info.yaml
+++ b/devices/samsungtv/samsung/un55ku630d/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: UN55KU630D
 model_raw: UN55KU630D
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/samsungtv/samsung/un55ru7100fxza/info.yaml
+++ b/devices/samsungtv/samsung/un55ru7100fxza/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: UN55RU7100FXZA
 model_raw: UN55RU7100FXZA
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/sense/sense-labs-inc/sense/info.yaml
+++ b/devices/sense/sense-labs-inc/sense/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sense Labs, Inc.
 manufacturer_raw: Sense Labs, Inc.
 model_name: Sense
 model_raw: Sense
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/sensibo/sensibo/skyplus/info.yaml
+++ b/devices/sensibo/sensibo/skyplus/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sensibo
 manufacturer_raw: Sensibo
 model_name: skyplus
 model_raw: skyplus
+same_as: null
 versions:
 - hardware: esp32
   software: SKY40144

--- a/devices/shelly/shelly/shelly-1pm/info.yaml
+++ b/devices/shelly/shelly/shelly-1pm/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Shelly
 manufacturer_raw: Shelly
 model_name: Shelly 1PM
 model_raw: Shelly 1PM
+same_as: null
 versions:
 - hardware: gen1 (SHSW-PM)
   software: 20230913-113709/v1.14.0-gcb84623

--- a/devices/shelly/shelly/shelly-2-5/info.yaml
+++ b/devices/shelly/shelly/shelly-2-5/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Shelly
 manufacturer_raw: Shelly
 model_name: Shelly 2.5
 model_raw: Shelly 2.5
+same_as: null
 versions:
 - hardware: gen1 (SHSW-25)
   software: 20230913-112234/v1.14.0-gcb84623

--- a/devices/shelly/shelly/shelly-2/info.yaml
+++ b/devices/shelly/shelly/shelly-2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Shelly
 manufacturer_raw: Shelly
 model_name: Shelly 2
 model_raw: Shelly 2
+same_as: null
 versions:
 - hardware: gen1 (SHSW-21)
   software: 20230913-112145/v1.14.0-gcb84623

--- a/devices/shelly/shelly/shelly-i3/info.yaml
+++ b/devices/shelly/shelly/shelly-i3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Shelly
 manufacturer_raw: Shelly
 model_name: Shelly i3
 model_raw: Shelly i3
+same_as: null
 versions:
 - hardware: gen1 (SHIX3-1)
   software: 20230913-114336/v1.14.0-gcb84623

--- a/devices/slimproto/slimproto-player/squeezeesp32/info.yaml
+++ b/devices/slimproto/slimproto-player/squeezeesp32/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: SlimProto Player
 manufacturer_raw: SlimProto Player
 model_name: SqueezeESP32
 model_raw: SqueezeESP32
+same_as: null
 versions:
 - hardware: v1.0-1670-16
 via_devices: null

--- a/devices/sma/sma/sunny-boy-6-0/info.yaml
+++ b/devices/sma/sma/sunny-boy-6-0/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: SMA
 manufacturer_raw: SMA
 model_name: Sunny Boy 6.0
 model_raw: Sunny Boy 6.0
+same_as: null
 versions:
 - software: 4.1.15.R
 via_devices: null

--- a/devices/sonos/apple/amp/info.yaml
+++ b/devices/sonos/apple/amp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Apple
 manufacturer_raw: Apple
 model_name: Amp
 model_raw: Amp
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/sonos/sonos/amp/info.yaml
+++ b/devices/sonos/sonos/amp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Amp
 model_raw: Amp
+same_as: null
 versions:
 - software: '16.1'
 - software: 16.1.1

--- a/devices/sonos/sonos/arc-sl/info.yaml
+++ b/devices/sonos/sonos/arc-sl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Arc SL
 model_raw: Arc SL
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/beam/info.yaml
+++ b/devices/sonos/sonos/beam/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Beam
 model_raw: Beam
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/connect-amp/info.yaml
+++ b/devices/sonos/sonos/connect-amp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Connect:Amp
 model_raw: Connect:Amp
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/five/info.yaml
+++ b/devices/sonos/sonos/five/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Five
 model_raw: Five
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/move/info.yaml
+++ b/devices/sonos/sonos/move/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Move
 model_raw: Move
+same_as: null
 versions:
 - software: '16.1'
 via_devices: null

--- a/devices/sonos/sonos/one/info.yaml
+++ b/devices/sonos/sonos/one/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: One
 model_raw: One
+same_as: null
 versions:
 - software: '16.2'
 - software: 16.1.1

--- a/devices/sonos/sonos/play-1/info.yaml
+++ b/devices/sonos/sonos/play-1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Play:1
 model_raw: Play:1
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/port/info.yaml
+++ b/devices/sonos/sonos/port/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Port
 model_raw: Port
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/roam-sl/info.yaml
+++ b/devices/sonos/sonos/roam-sl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Roam SL
 model_raw: Roam SL
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/roam/info.yaml
+++ b/devices/sonos/sonos/roam/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: Roam
 model_raw: Roam
+same_as: null
 versions:
 - software: '16.2'
 - software: 16.1.1

--- a/devices/sonos/sonos/symfonisk-bookshelf/info.yaml
+++ b/devices/sonos/sonos/symfonisk-bookshelf/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: SYMFONISK Bookshelf
 model_raw: SYMFONISK Bookshelf
+same_as: null
 versions:
 - software: '16.2'
 - software: 16.1.1

--- a/devices/sonos/sonos/symfonisk-picture-frame/info.yaml
+++ b/devices/sonos/sonos/symfonisk-picture-frame/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: SYMFONISK Picture frame
 model_raw: SYMFONISK Picture frame
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/sonos/sonos/symfonisk-table-lamp/info.yaml
+++ b/devices/sonos/sonos/symfonisk-table-lamp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sonos
 manufacturer_raw: Sonos
 model_name: SYMFONISK Table lamp
 model_raw: SYMFONISK Table lamp
+same_as: null
 versions:
 - software: '16.2'
 via_devices: null

--- a/devices/switchbot_cloud/switchbot/diy-light/info.yaml
+++ b/devices/switchbot_cloud/switchbot/diy-light/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: SwitchBot
 manufacturer_raw: SwitchBot
 model_name: DIY Light
 model_raw: DIY Light
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/synology_dsm/samsung/samsung-ssd-960-evo-500gb/info.yaml
+++ b/devices/synology_dsm/samsung/samsung-ssd-960-evo-500gb/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Samsung
 manufacturer_raw: Samsung
 model_name: Samsung SSD 960 EVO 500GB
 model_raw: Samsung SSD 960 EVO 500GB
+same_as: null
 versions:
 - software: 3B7QCXE7
 via_devices: null

--- a/devices/synology_dsm/synology/ds920/info.yaml
+++ b/devices/synology_dsm/synology/ds920/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Synology
 manufacturer_raw: Synology
 model_name: DS920+
 model_raw: DS920+
+same_as: null
 versions:
 - software: DSM 6.2.4-25556 Update 7
 - software: 9.2.0-9289

--- a/devices/synology_dsm/wdc/wd100efax-68lhpn0/info.yaml
+++ b/devices/synology_dsm/wdc/wd100efax-68lhpn0/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: 'WDC     '
 manufacturer_raw: 'WDC     '
 model_name: WD100EFAX-68LHPN0
 model_raw: WD100EFAX-68LHPN0
+same_as: null
 versions:
 - software: 83.H0A83
 via_devices: null

--- a/devices/system_bridge/avm/fritz-box-tracked-device/info.yaml
+++ b/devices/system_bridge/avm/fritz-box-tracked-device/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AVM
 manufacturer_raw: AVM
 model_name: FRITZ!Box Tracked device
 model_raw: FRITZ!Box Tracked device
+same_as: null
 versions:
 - software: 4.1.10
 via_devices: null

--- a/devices/tesla_wall_connector/tesla/1457768-02-g/info.yaml
+++ b/devices/tesla_wall_connector/tesla/1457768-02-g/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: 1457768-02-G
 model_raw: 1457768-02-G
+same_as: null
 versions:
 - software: 24.12.51+g7855f626d7fb3
 via_devices: null

--- a/devices/tesla_wall_connector/tesla/1457768-02-h/info.yaml
+++ b/devices/tesla_wall_connector/tesla/1457768-02-h/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tesla
 manufacturer_raw: Tesla
 model_name: 1457768-02-H
 model_raw: 1457768-02-H
+same_as: null
 versions:
 - software: 24.12.51+g7855f626d7fb3
 via_devices: null

--- a/devices/tplink/tp-link/ep25/info.yaml
+++ b/devices/tplink/tp-link/ep25/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: EP25
 model_raw: EP25
+same_as: null
 versions:
 - hardware: '2.6'
   software: 1.0.2 Build 231108 Rel.163012

--- a/devices/tplink/tp-link/hs103-us/info.yaml
+++ b/devices/tplink/tp-link/hs103-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: HS103(US)
 model_raw: HS103(US)
+same_as: null
 versions:
 - hardware: '5.0'
   software: 1.0.3 Build 201015 Rel.142523

--- a/devices/tplink/tp-link/hs110-us/info.yaml
+++ b/devices/tplink/tp-link/hs110-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: HS110(US)
 model_raw: HS110(US)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.2.5 Build 171206 Rel.085954

--- a/devices/tplink/tp-link/hs220-us/info.yaml
+++ b/devices/tplink/tp-link/hs220-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: HS220(US)
 model_raw: HS220(US)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.5.5 Build 180717 Rel.155202

--- a/devices/tplink/tp-link/hs300-us/info.yaml
+++ b/devices/tplink/tp-link/hs300-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: HS300(US)
 model_raw: HS300(US)
+same_as: null
 versions:
 - hardware: '2.0'
   software: 1.0.12 Build 220121 Rel.175814

--- a/devices/tplink/tp-link/kl125-us/info.yaml
+++ b/devices/tplink/tp-link/kl125-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KL125(US)
 model_raw: KL125(US)
+same_as: null
 versions:
 - hardware: '4.0'
   software: 1.0.5 Build 230613 Rel.151643

--- a/devices/tplink/tp-link/kl130-us/info.yaml
+++ b/devices/tplink/tp-link/kl130-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KL130(US)
 model_raw: KL130(US)
+same_as: null
 versions:
 - hardware: '2.0'
   software: 1.0.13 Build 211217 Rel.170501

--- a/devices/tplink/tp-link/kl420l5-us/info.yaml
+++ b/devices/tplink/tp-link/kl420l5-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KL420L5(US)
 model_raw: KL420L5(US)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.2 Build 211009 Rel.164949

--- a/devices/tplink/tp-link/kl430-us/info.yaml
+++ b/devices/tplink/tp-link/kl430-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KL430(US)
 model_raw: KL430(US)
+same_as: null
 versions:
 - hardware: '2.0'
   software: 1.0.9 Build 210915 Rel.170534

--- a/devices/tplink/tp-link/kp105-au/info.yaml
+++ b/devices/tplink/tp-link/kp105-au/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KP105(AU)
 model_raw: KP105(AU)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.2 Build 200915 Rel.150823

--- a/devices/tplink/tp-link/kp115-au/info.yaml
+++ b/devices/tplink/tp-link/kp115-au/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KP115(AU)
 model_raw: KP115(AU)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.7 Build 200825 Rel.091621

--- a/devices/tplink/tp-link/kp125-us/info.yaml
+++ b/devices/tplink/tp-link/kp125-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KP125(US)
 model_raw: KP125(US)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.8 Build 220130 Rel.174717

--- a/devices/tplink/tp-link/kp200-us/info.yaml
+++ b/devices/tplink/tp-link/kp200-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KP200(US)
 model_raw: KP200(US)
+same_as: null
 versions:
 - hardware: '3.0'
   software: 1.0.3 Build 221021 Rel.183354

--- a/devices/tplink/tp-link/kp401-us/info.yaml
+++ b/devices/tplink/tp-link/kp401-us/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KP401(US)
 model_raw: KP401(US)
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.0 Build 201221 Rel.090515

--- a/devices/tplink/tp-link/ks240/info.yaml
+++ b/devices/tplink/tp-link/ks240/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: KS240
 model_raw: KS240
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.4 Build 230721 Rel.184322

--- a/devices/tplink/tp-link/l510/info.yaml
+++ b/devices/tplink/tp-link/l510/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: L510
 model_raw: L510
+same_as: null
 versions:
 - hardware: '3.0'
   software: 1.1.2 Build 231120 Rel.201048

--- a/devices/tplink/tp-link/l900/info.yaml
+++ b/devices/tplink/tp-link/l900/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: L900
 model_raw: L900
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.11 Build 220119 Rel.221258

--- a/devices/tplink/tp-link/l920/info.yaml
+++ b/devices/tplink/tp-link/l920/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: L920
 model_raw: L920
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.1.3 Build 231229 Rel.164316

--- a/devices/tplink/tp-link/p125m/info.yaml
+++ b/devices/tplink/tp-link/p125m/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: P125M
 model_raw: P125M
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.2.2 Build 240305 Rel.093138

--- a/devices/tplink/tp-link/tp15/info.yaml
+++ b/devices/tplink/tp-link/tp15/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: TP15
 model_raw: TP15
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.3 Build 230112 Rel.124621

--- a/devices/tplink/tp-link/tp25/info.yaml
+++ b/devices/tplink/tp-link/tp25/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: TP25
 model_raw: TP25
+same_as: null
 versions:
 - hardware: '1.0'
   software: 1.0.2 Build 230206 Rel.095245

--- a/devices/tplink_omada/tp-link/eap660-hd-us-v1-0/info.yaml
+++ b/devices/tplink_omada/tp-link/eap660-hd-us-v1-0/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: TP-Link
 manufacturer_raw: TP-Link
 model_name: EAP660 HD(US) v1.0
 model_raw: EAP660 HD(US) v1.0
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/air-purifier-5a4rez30alfjfmdg/info.yaml
+++ b/devices/tuya/tuya/air-purifier-5a4rez30alfjfmdg/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Air purifier (5a4rez30alfjfmdg)
 model_raw: Air purifier (5a4rez30alfjfmdg)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/ds01c-smart-dimmer-switch-r3fg1ytyd4sd67ga/info.yaml
+++ b/devices/tuya/tuya/ds01c-smart-dimmer-switch-r3fg1ytyd4sd67ga/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: DS01C Smart dimmer switch (r3fg1ytyd4sd67ga)
 model_raw: DS01C Smart dimmer switch (r3fg1ytyd4sd67ga)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/fairy-lights-rqsvgaquywwekm6x/info.yaml
+++ b/devices/tuya/tuya/fairy-lights-rqsvgaquywwekm6x/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Fairy Lights  (rqsvgaquywwekm6x)
 model_raw: Fairy Lights  (rqsvgaquywwekm6x)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/hdf9m2mq0g116ag4/info.yaml
+++ b/devices/tuya/tuya/hdf9m2mq0g116ag4/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: ' (hdf9m2mq0g116ag4)'
 model_raw: ' (hdf9m2mq0g116ag4)'
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/smart-amari-ceiling-fan-zjqqpvhra3ep0fpk/info.yaml
+++ b/devices/tuya/tuya/smart-amari-ceiling-fan-zjqqpvhra3ep0fpk/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Smart Amari Ceiling Fan (zjqqpvhra3ep0fpk)
 model_raw: Smart Amari Ceiling Fan (zjqqpvhra3ep0fpk)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/smart-ceiling-fan-lvl9k0xfqubcga9v/info.yaml
+++ b/devices/tuya/tuya/smart-ceiling-fan-lvl9k0xfqubcga9v/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Smart Ceiling Fan (lvl9k0xfqubcga9v)
 model_raw: Smart Ceiling Fan (lvl9k0xfqubcga9v)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/smart-mood-light-v91ayo8kjwboclce/info.yaml
+++ b/devices/tuya/tuya/smart-mood-light-v91ayo8kjwboclce/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Smart Mood Light (v91ayo8kjwboclce)
 model_raw: Smart Mood Light (v91ayo8kjwboclce)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/smart-plug-uht9kh2h10iebayn/info.yaml
+++ b/devices/tuya/tuya/smart-plug-uht9kh2h10iebayn/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Smart Plug (uht9kh2h10iebayn)
 model_raw: Smart Plug (uht9kh2h10iebayn)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/vonluce-smart-ceiling-fan-vdqtvr0uqnrflobk/info.yaml
+++ b/devices/tuya/tuya/vonluce-smart-ceiling-fan-vdqtvr0uqnrflobk/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: Vonluce Smart Ceiling Fan (vdqtvr0uqnrflobk)
 model_raw: Vonluce Smart Ceiling Fan (vdqtvr0uqnrflobk)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/wifi-controller-gsxa4al2dd4uonna/info.yaml
+++ b/devices/tuya/tuya/wifi-controller-gsxa4al2dd4uonna/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: WiFi controller (gsxa4al2dd4uonna)
 model_raw: WiFi controller (gsxa4al2dd4uonna)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/tuya/tuya/yuhao-dcfan-uoebyc4b8it0eh09/info.yaml
+++ b/devices/tuya/tuya/yuhao-dcfan-uoebyc4b8it0eh09/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Tuya
 manufacturer_raw: Tuya
 model_name: YuHao dcFan (uoebyc4b8it0eh09)
 model_raw: YuHao dcFan (uoebyc4b8it0eh09)
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/unifiprotect/ubiquiti/uck-g2-plus/info.yaml
+++ b/devices/unifiprotect/ubiquiti/uck-g2-plus/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ubiquiti
 manufacturer_raw: Ubiquiti
 model_name: UCK-G2-PLUS
 model_raw: UCK-G2-PLUS
+same_as: null
 versions:
 - software: 4.0.21
 via_devices: null

--- a/devices/unifiprotect/ubiquiti/udm-pro-se/info.yaml
+++ b/devices/unifiprotect/ubiquiti/udm-pro-se/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ubiquiti
 manufacturer_raw: Ubiquiti
 model_name: UDM-PRO-SE
 model_raw: UDM-PRO-SE
+same_as: null
 versions:
 - hardware: '26'
   software: 4.0.33

--- a/devices/unifiprotect/ubiquiti/udm-pro/info.yaml
+++ b/devices/unifiprotect/ubiquiti/udm-pro/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ubiquiti
 manufacturer_raw: Ubiquiti
 model_name: UDM-PRO
 model_raw: UDM-PRO
+same_as: null
 versions:
 - software: 4.0.21
 via_devices: null

--- a/devices/unifiprotect/ubiquiti/unvr4/info.yaml
+++ b/devices/unifiprotect/ubiquiti/unvr4/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ubiquiti
 manufacturer_raw: Ubiquiti
 model_name: UNVR4
 model_raw: UNVR4
+same_as: null
 versions:
 - software: 4.0.33
 via_devices: null

--- a/devices/upnp/asustek-computer-inc/rt-ax3000/info.yaml
+++ b/devices/upnp/asustek-computer-inc/rt-ax3000/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ASUSTeK Computer Inc.
 manufacturer_raw: ASUSTeK Computer Inc.
 model_name: RT-AX3000
 model_raw: RT-AX3000
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/v2c/v2c/trydan/info.yaml
+++ b/devices/v2c/v2c/trydan/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: V2C
 manufacturer_raw: V2C
 model_name: Trydan
 model_raw: Trydan
+same_as: null
 versions:
 - software: 2.1.7
 via_devices: null

--- a/devices/vesync/vesync/core200s/info.yaml
+++ b/devices/vesync/vesync/core200s/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VeSync
 manufacturer_raw: VeSync
 model_name: Core200S
 model_raw: Core200S
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/vesync/vesync/lap-v102s-wus/info.yaml
+++ b/devices/vesync/vesync/lap-v102s-wus/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VeSync
 manufacturer_raw: VeSync
 model_name: LAP-V102S-WUS
 model_raw: LAP-V102S-WUS
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/vesync/vesync/luh-a602s-wus/info.yaml
+++ b/devices/vesync/vesync/luh-a602s-wus/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VeSync
 manufacturer_raw: VeSync
 model_name: LUH-A602S-WUS
 model_raw: LUH-A602S-WUS
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/vizio/vizio/e43u-d2/info.yaml
+++ b/devices/vizio/vizio/e43u-d2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VIZIO
 manufacturer_raw: VIZIO
 model_name: E43u-D2
 model_raw: E43u-D2
+same_as: null
 versions:
 - software: 11.0.120.1-1
 via_devices: null

--- a/devices/vizio/vizio/v505-h9/info.yaml
+++ b/devices/vizio/vizio/v505-h9/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VIZIO
 manufacturer_raw: VIZIO
 model_name: V505-H9
 model_raw: V505-H9
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/vizio/vizio/v655-h9/info.yaml
+++ b/devices/vizio/vizio/v655-h9/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: VIZIO
 manufacturer_raw: VIZIO
 model_name: V655-H9
 model_raw: V655-H9
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/voip/grandstream/ht801/info.yaml
+++ b/devices/voip/grandstream/ht801/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Grandstream
 manufacturer_raw: Grandstream
 model_name: HT801
 model_raw: HT801
+same_as: null
 versions:
 - software: 1.0.51.1
 - software: 1.0.43.11

--- a/devices/webostv/lg/32lm631c0za/info.yaml
+++ b/devices/webostv/lg/32lm631c0za/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LG
 manufacturer_raw: LG
 model_name: 32LM631C0ZA
 model_raw: 32LM631C0ZA
+same_as: null
 versions:
 - software: 05.40.20
 via_devices: null

--- a/devices/webostv/lg/43up77006lb/info.yaml
+++ b/devices/webostv/lg/43up77006lb/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LG
 manufacturer_raw: LG
 model_name: 43UP77006LB
 model_raw: 43UP77006LB
+same_as: null
 versions:
 - software: 03.40.82
 via_devices: null

--- a/devices/webostv/lg/55uh6150-ub/info.yaml
+++ b/devices/webostv/lg/55uh6150-ub/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LG
 manufacturer_raw: LG
 model_name: 55UH6150-UB
 model_raw: 55UH6150-UB
+same_as: null
 versions:
 - software: 05.65.03
 via_devices: null

--- a/devices/webostv/lg/oled55b9pla/info.yaml
+++ b/devices/webostv/lg/oled55b9pla/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LG
 manufacturer_raw: LG
 model_name: OLED55B9PLA
 model_raw: OLED55B9PLA
+same_as: null
 versions:
 - software: 05.40.20
 via_devices: null

--- a/devices/wemo/belkin/dli-emulated-belkin-socket/info.yaml
+++ b/devices/wemo/belkin/dli-emulated-belkin-socket/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Belkin
 manufacturer_raw: Belkin
 model_name: DLI emulated Belkin socket
 model_raw: DLI emulated Belkin socket
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/wemo/belkin/insight/info.yaml
+++ b/devices/wemo/belkin/insight/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Belkin
 manufacturer_raw: Belkin
 model_name: Insight
 model_raw: Insight
+same_as: null
 versions:
 - software: WeMo_WW_2.00.11396.PVT-OWRT-Insight
 via_devices: null

--- a/devices/xiaomi_miio/xiaomi/rockrobo-vacuum-v1/info.yaml
+++ b/devices/xiaomi_miio/xiaomi/rockrobo-vacuum-v1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Xiaomi
 manufacturer_raw: Xiaomi
 model_name: rockrobo.vacuum.v1
 model_raw: rockrobo.vacuum.v1
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/yalexs_ble/assaabloy-inc/md-01/info.yaml
+++ b/devices/yalexs_ble/assaabloy-inc/md-01/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ASSAABLOY Inc.
 manufacturer_raw: ASSAABLOY Inc.
 model_name: MD-01
 model_raw: MD-01
+same_as: null
 versions:
 - software: 2.2.5
 via_devices: null

--- a/devices/yalexs_ble/assaabloy-inc/yrsm-1/info.yaml
+++ b/devices/yalexs_ble/assaabloy-inc/yrsm-1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ASSAABLOY Inc.
 manufacturer_raw: ASSAABLOY Inc.
 model_name: YRSM-1
 model_raw: YRSM-1
+same_as: null
 versions:
 - software: 2.0.8
 via_devices: null

--- a/devices/yalexs_ble/august-home-inc/asl-03/info.yaml
+++ b/devices/yalexs_ble/august-home-inc/asl-03/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: ASL-03
 model_raw: ASL-03
+same_as: null
 versions:
 - software: 2.0.6
 via_devices: null

--- a/devices/yalexs_ble/august-home-inc/md-01/info.yaml
+++ b/devices/yalexs_ble/august-home-inc/md-01/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: MD-01
 model_raw: MD-01
+same_as: null
 versions:
 - software: 2.0.5
 via_devices: null

--- a/devices/yalexs_ble/august-home-inc/md-02/info.yaml
+++ b/devices/yalexs_ble/august-home-inc/md-02/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home Inc.
 manufacturer_raw: August Home Inc.
 model_name: MD-02
 model_raw: MD-02
+same_as: null
 versions:
 - software: 2.1.18
 via_devices: null

--- a/devices/yalexs_ble/august-manuf-name-here/august-model-number-here/info.yaml
+++ b/devices/yalexs_ble/august-manuf-name-here/august-model-number-here/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AUGUST_MANUF_NAME_HERE
 manufacturer_raw: AUGUST_MANUF_NAME_HERE
 model_name: AUGUST_MODEL_NUMBER_HERE
 model_raw: AUGUST_MODEL_NUMBER_HERE
+same_as: null
 versions:
 - software: 1.0.19
 - software: 1.3.16

--- a/devices/yalexs_ble/card-access-inc/md-05/info.yaml
+++ b/devices/yalexs_ble/card-access-inc/md-05/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Card Access Inc.
 manufacturer_raw: Card Access Inc.
 model_name: MD-05
 model_raw: MD-05
+same_as: null
 versions:
 - software: 1.0.20
 via_devices: null

--- a/devices/yalexs_ble/yale/md-04i/info.yaml
+++ b/devices/yalexs_ble/yale/md-04i/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: yale
 manufacturer_raw: yale
 model_name: MD-04I
 model_raw: MD-04I
+same_as: null
 versions:
 - software: 1.0.16
 via_devices: null

--- a/devices/yamaha_musiccast/yamaha-corporation/rx-v685/info.yaml
+++ b/devices/yamaha_musiccast/yamaha-corporation/rx-v685/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Yamaha Corporation
 manufacturer_raw: Yamaha Corporation
 model_name: RX-V685
 model_raw: RX-V685
+same_as: null
 versions:
 - software: '2.13'
 - software: '2.07'

--- a/devices/yeelight/yeelight/lamp15/info.yaml
+++ b/devices/yeelight/yeelight/lamp15/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Yeelight
 manufacturer_raw: Yeelight
 model_name: lamp15
 model_raw: lamp15
+same_as: null
 versions:
 - software: '38'
 via_devices: null

--- a/devices/zha/danfoss/etrv0103/info.yaml
+++ b/devices/zha/danfoss/etrv0103/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Danfoss
 manufacturer_raw: Danfoss
 model_name: eTRV0103
 model_raw: eTRV0103
+same_as: null
 versions:
 - software: '0x00000014'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/badring-water-leakage-sensor/info.yaml
+++ b/devices/zha/ikea-of-sweden/badring-water-leakage-sensor/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: BADRING Water Leakage Sensor
 model_raw: BADRING Water Leakage Sensor
+same_as: null
 versions:
 - software: '0x01000007'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/remote-control-n2/info.yaml
+++ b/devices/zha/ikea-of-sweden/remote-control-n2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: Remote Control N2
 model_raw: Remote Control N2
+same_as: null
 versions:
 - software: '0x02040005'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/rodret-dimmer/info.yaml
+++ b/devices/zha/ikea-of-sweden/rodret-dimmer/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: RODRET Dimmer
 model_raw: RODRET Dimmer
+same_as: null
 versions:
 - software: '0x01000047'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/somrig-shortcut-button/info.yaml
+++ b/devices/zha/ikea-of-sweden/somrig-shortcut-button/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: SOMRIG shortcut button
 model_raw: SOMRIG shortcut button
+same_as: null
 versions:
 - software: '0x01000020'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/starkvind-air-purifier-table/info.yaml
+++ b/devices/zha/ikea-of-sweden/starkvind-air-purifier-table/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: STARKVIND Air purifier table
 model_raw: STARKVIND Air purifier table
+same_as: null
 versions:
 - software: '0x00010033'
 - software: '0x00011001'

--- a/devices/zha/ikea-of-sweden/symfonisk-sound-remote-gen2/info.yaml
+++ b/devices/zha/ikea-of-sweden/symfonisk-sound-remote-gen2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: SYMFONISK sound remote gen2
 model_raw: SYMFONISK sound remote gen2
+same_as: null
 versions:
 - software: '0x01000035'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/tradfri-bulb-e12-cws-opal-600lm/info.yaml
+++ b/devices/zha/ikea-of-sweden/tradfri-bulb-e12-cws-opal-600lm/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: TRADFRI bulb E12 CWS opal 600lm
 model_raw: TRADFRI bulb E12 CWS opal 600lm
+same_as: null
 versions:
 - software: '0x13009572'
 via_devices:

--- a/devices/zha/ikea-of-sweden/tretakt-smart-plug/info.yaml
+++ b/devices/zha/ikea-of-sweden/tretakt-smart-plug/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: TRETAKT Smart plug
 model_raw: TRETAKT Smart plug
+same_as: null
 versions:
 - software: '0x02040004'
 via_devices: null

--- a/devices/zha/ikea-of-sweden/vindstyrka/info.yaml
+++ b/devices/zha/ikea-of-sweden/vindstyrka/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: IKEA of Sweden
 manufacturer_raw: IKEA of Sweden
 model_name: VINDSTYRKA
 model_raw: VINDSTYRKA
+same_as: null
 versions:
 - software: '0x00010010'
 - software: '0x01000011'

--- a/devices/zha/innr/osp-210/info.yaml
+++ b/devices/zha/innr/osp-210/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: innr
 manufacturer_raw: innr
 model_name: OSP 210
 model_raw: OSP 210
+same_as: null
 versions:
 - software: '0x11003674'
 via_devices: null

--- a/devices/zha/lumi/lumi-motion-ac02/info.yaml
+++ b/devices/zha/lumi/lumi-motion-ac02/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.motion.ac02
 model_raw: lumi.motion.ac02
+same_as: null
 versions:
 - software: '0x00000006'
 - {}

--- a/devices/zha/lumi/lumi-sensor-cube-aqgl01/info.yaml
+++ b/devices/zha/lumi/lumi-sensor-cube-aqgl01/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.sensor_cube.aqgl01
 model_raw: lumi.sensor_cube.aqgl01
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/zha/lumi/lumi-sensor-magnet-aq2/info.yaml
+++ b/devices/zha/lumi/lumi-sensor-magnet-aq2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.sensor_magnet.aq2
 model_raw: lumi.sensor_magnet.aq2
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/zha/lumi/lumi-sensor-motion-aq2/info.yaml
+++ b/devices/zha/lumi/lumi-sensor-motion-aq2/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.sensor_motion.aq2
 model_raw: lumi.sensor_motion.aq2
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/zha/lumi/lumi-sensor-smoke-acn03/info.yaml
+++ b/devices/zha/lumi/lumi-sensor-smoke-acn03/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.sensor_smoke.acn03
 model_raw: lumi.sensor_smoke.acn03
+same_as: null
 versions:
 - software: '0x00000011'
 - software: '0x00000013'

--- a/devices/zha/lumi/lumi-sensor-wleak-aq1/info.yaml
+++ b/devices/zha/lumi/lumi-sensor-wleak-aq1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.sensor_wleak.aq1
 model_raw: lumi.sensor_wleak.aq1
+same_as: null
 versions:
 - {}
 via_devices:

--- a/devices/zha/lumi/lumi-weather/info.yaml
+++ b/devices/zha/lumi/lumi-weather/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: LUMI
 manufacturer_raw: LUMI
 model_name: lumi.weather
 model_raw: lumi.weather
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/zha/lutron/z3-1brl/info.yaml
+++ b/devices/zha/lutron/z3-1brl/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Lutron
 manufacturer_raw: Lutron
 model_name: Z3-1BRL
 model_raw: Z3-1BRL
+same_as: null
 versions:
 - software: '0x00000c08'
 via_devices:

--- a/devices/zha/philips/7602031p7/info.yaml
+++ b/devices/zha/philips/7602031p7/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Philips
 manufacturer_raw: Philips
 model_name: 7602031P7
 model_raw: 7602031P7
+same_as: null
 versions:
 - software: '0x01002002'
 via_devices: null

--- a/devices/zha/philips/lct001/info.yaml
+++ b/devices/zha/philips/lct001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Philips
 manufacturer_raw: Philips
 model_name: LCT001
 model_raw: LCT001
+same_as: null
 versions:
 - software: '0x420052b1'
 via_devices:

--- a/devices/zha/philips/rwl020/info.yaml
+++ b/devices/zha/philips/rwl020/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Philips
 manufacturer_raw: Philips
 model_name: RWL020
 model_raw: RWL020
+same_as: null
 versions:
 - software: '0x420045b6'
 via_devices:

--- a/devices/zha/phoscon/hive/info.yaml
+++ b/devices/zha/phoscon/hive/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Phoscon
 manufacturer_raw: Phoscon
 model_name: Hive
 model_raw: Hive
+same_as: null
 versions:
 - software: '0x00200018'
 via_devices: null

--- a/devices/zha/signify-netherlands-b-v/lca006/info.yaml
+++ b/devices/zha/signify-netherlands-b-v/lca006/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: LCA006
 model_raw: LCA006
+same_as: null
 versions:
 - software: '0x01001f0a'
 via_devices: null

--- a/devices/zha/signify-netherlands-b-v/lce002/info.yaml
+++ b/devices/zha/signify-netherlands-b-v/lce002/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Signify Netherlands B.V.
 manufacturer_raw: Signify Netherlands B.V.
 model_name: LCE002
 model_raw: LCE002
+same_as: null
 versions:
 - software: '0x01001f0a'
 via_devices: null

--- a/devices/zha/silicon-labs/ezsp/info.yaml
+++ b/devices/zha/silicon-labs/ezsp/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Silicon Labs
 manufacturer_raw: Silicon Labs
 model_name: EZSP
 model_raw: EZSP
+same_as: null
 versions:
 - software: 7.3.1.0 build 176
 via_devices: null

--- a/devices/zha/tz3000-2putqrmw/ts011f/info.yaml
+++ b/devices/zha/tz3000-2putqrmw/ts011f/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: _TZ3000_2putqrmw
 manufacturer_raw: _TZ3000_2putqrmw
 model_name: TS011F
 model_raw: TS011F
+same_as: null
 versions:
 - software: '0x0000004d'
 via_devices: null

--- a/devices/zha/tze200-arge1ptm/ts0601/info.yaml
+++ b/devices/zha/tze200-arge1ptm/ts0601/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: _TZE200_arge1ptm
 manufacturer_raw: _TZE200_arge1ptm
 model_name: TS0601
 model_raw: TS0601
+same_as: null
 versions:
 - {}
 via_devices: null

--- a/devices/zwave_js/abus-security-center-gmbh-co-kg/shsg10000/info.yaml
+++ b/devices/zwave_js/abus-security-center-gmbh-co-kg/shsg10000/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: ABUS Security-Center GmbH & Co. KG
 manufacturer_raw: ABUS Security-Center GmbH & Co. KG
 model_name: SHSG10000
 model_raw: SHSG10000
+same_as: null
 versions:
 - software: 1.2.1
 via_devices: null

--- a/devices/zwave_js/aeon-labs/zw090/info.yaml
+++ b/devices/zwave_js/aeon-labs/zw090/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: AEON Labs
 manufacturer_raw: AEON Labs
 model_name: ZW090
 model_raw: ZW090
+same_as: null
 versions:
 - software: '1.1'
 via_devices: null

--- a/devices/zwave_js/aeotec-ltd/zw164/info.yaml
+++ b/devices/zwave_js/aeotec-ltd/zw164/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Aeotec Ltd.
 manufacturer_raw: Aeotec Ltd.
 model_name: ZW164
 model_raw: ZW164
+same_as: null
 versions:
 - software: '1.9'
 via_devices: null

--- a/devices/zwave_js/aeotec-ltd/zw175/info.yaml
+++ b/devices/zwave_js/aeotec-ltd/zw175/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Aeotec Ltd.
 manufacturer_raw: Aeotec Ltd.
 model_name: ZW175
 model_raw: ZW175
+same_as: null
 versions:
 - software: '1.2'
 via_devices: null

--- a/devices/zwave_js/august-home/asl-03/info.yaml
+++ b/devices/zwave_js/august-home/asl-03/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: August Home
 manufacturer_raw: August Home
 model_name: ASL-03
 model_raw: ASL-03
+same_as: null
 versions:
 - software: '1.59'
 via_devices: null

--- a/devices/zwave_js/ecolink/ff-zwave5-eco/info.yaml
+++ b/devices/zwave_js/ecolink/ff-zwave5-eco/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ecolink
 manufacturer_raw: Ecolink
 model_name: FF-ZWAVE5-ECO
 model_raw: FF-ZWAVE5-ECO
+same_as: null
 versions:
 - software: '11.2'
 via_devices: null

--- a/devices/zwave_js/ecolink/h214104/info.yaml
+++ b/devices/zwave_js/ecolink/h214104/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ecolink
 manufacturer_raw: Ecolink
 model_name: H214104
 model_raw: H214104
+same_as: null
 versions:
 - software: '10.9'
 via_devices: null

--- a/devices/zwave_js/first-alert-brk-brands-inc/zcombo/info.yaml
+++ b/devices/zwave_js/first-alert-brk-brands-inc/zcombo/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: First Alert (BRK Brands Inc)
 manufacturer_raw: First Alert (BRK Brands Inc)
 model_name: ZCOMBO
 model_raw: ZCOMBO
+same_as: null
 versions:
 - software: 11.0.0
 via_devices:

--- a/devices/zwave_js/ge/12721-zw1001/info.yaml
+++ b/devices/zwave_js/ge/12721-zw1001/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: GE
 manufacturer_raw: GE
 model_name: 12721 / ZW1001
 model_raw: 12721 / ZW1001
+same_as: null
 versions:
 - software: '1.27'
 via_devices: null

--- a/devices/zwave_js/ge/14284-zw4201/info.yaml
+++ b/devices/zwave_js/ge/14284-zw4201/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: GE
 manufacturer_raw: GE
 model_name: 14284 / ZW4201
 model_raw: 14284 / ZW4201
+same_as: null
 versions:
 - software: '5.21'
 via_devices: null

--- a/devices/zwave_js/ge/14287-zw4002/info.yaml
+++ b/devices/zwave_js/ge/14287-zw4002/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: GE
 manufacturer_raw: GE
 model_name: 14287 / ZW4002
 model_raw: 14287 / ZW4002
+same_as: null
 versions:
 - software: '5.24'
 via_devices: null

--- a/devices/zwave_js/ge/14291-zw4005/info.yaml
+++ b/devices/zwave_js/ge/14291-zw4005/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: GE
 manufacturer_raw: GE
 model_name: 14291 / ZW4005
 model_raw: 14291 / ZW4005
+same_as: null
 versions:
 - software: '5.24'
 via_devices: null

--- a/devices/zwave_js/honeywell/th6320zw/info.yaml
+++ b/devices/zwave_js/honeywell/th6320zw/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Honeywell
 manufacturer_raw: Honeywell
 model_name: TH6320ZW
 model_raw: TH6320ZW
+same_as: null
 versions:
 - software: '1.3'
 via_devices: null

--- a/devices/zwave_js/inovelli/lzw31-sn/info.yaml
+++ b/devices/zwave_js/inovelli/lzw31-sn/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Inovelli
 manufacturer_raw: Inovelli
 model_name: LZW31-SN
 model_raw: LZW31-SN
+same_as: null
 versions:
 - software: '1.57'
 via_devices: null

--- a/devices/zwave_js/inovelli/lzw36/info.yaml
+++ b/devices/zwave_js/inovelli/lzw36/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Inovelli
 manufacturer_raw: Inovelli
 model_name: LZW36
 model_raw: LZW36
+same_as: null
 versions:
 - software: 1.36.1
 via_devices: null

--- a/devices/zwave_js/inovelli/lzw45/info.yaml
+++ b/devices/zwave_js/inovelli/lzw45/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Inovelli
 manufacturer_raw: Inovelli
 model_name: LZW45
 model_raw: LZW45
+same_as: null
 versions:
 - software: 1.20.1
 via_devices: null

--- a/devices/zwave_js/kwikset/smartcode-888/info.yaml
+++ b/devices/zwave_js/kwikset/smartcode-888/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Kwikset
 manufacturer_raw: Kwikset
 model_name: SmartCode 888
 model_raw: SmartCode 888
+same_as: null
 versions:
 - software: '4.79'
 via_devices: null

--- a/devices/zwave_js/leviton/dz15s/info.yaml
+++ b/devices/zwave_js/leviton/dz15s/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Leviton
 manufacturer_raw: Leviton
 model_name: DZ15S
 model_raw: DZ15S
+same_as: null
 versions:
 - software: '1.23'
 via_devices: null

--- a/devices/zwave_js/leviton/dz6hd/info.yaml
+++ b/devices/zwave_js/leviton/dz6hd/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Leviton
 manufacturer_raw: Leviton
 model_name: DZ6HD
 model_raw: DZ6HD
+same_as: null
 versions:
 - software: '1.20'
 via_devices: null

--- a/devices/zwave_js/leviton/dzpd3/info.yaml
+++ b/devices/zwave_js/leviton/dzpd3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Leviton
 manufacturer_raw: Leviton
 model_name: DZPD3
 model_raw: DZPD3
+same_as: null
 versions:
 - software: '1.20'
 via_devices: null

--- a/devices/zwave_js/ring/4ak1sz/info.yaml
+++ b/devices/zwave_js/ring/4ak1sz/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ring
 manufacturer_raw: Ring
 model_name: 4AK1SZ
 model_raw: 4AK1SZ
+same_as: null
 versions:
 - software: 1.18.0
 via_devices: null

--- a/devices/zwave_js/shelly-europe-ltd/qnpl-001x16/info.yaml
+++ b/devices/zwave_js/shelly-europe-ltd/qnpl-001x16/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Shelly Europe Ltd.
 manufacturer_raw: Shelly Europe Ltd.
 model_name: QNPL-001X16
 model_raw: QNPL-001X16
+same_as: null
 versions:
 - software: 10.11.0
 via_devices:

--- a/devices/zwave_js/sigma-designs-former-zensys/husbzb-1/info.yaml
+++ b/devices/zwave_js/sigma-designs-former-zensys/husbzb-1/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Sigma Designs (Former Zensys)
 manufacturer_raw: Sigma Designs (Former Zensys)
 model_name: HUSBZB-1
 model_raw: HUSBZB-1
+same_as: null
 versions:
 - software: '4.32'
 via_devices: null

--- a/devices/zwave_js/silicon-labs/700-800-series/info.yaml
+++ b/devices/zwave_js/silicon-labs/700-800-series/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Silicon Labs
 manufacturer_raw: Silicon Labs
 model_name: 700/800 Series
 model_raw: 700/800 Series
+same_as: null
 versions:
 - software: 7.17.2
 - software: 7.15.1

--- a/devices/zwave_js/silicon-labs/acc-uzb3/info.yaml
+++ b/devices/zwave_js/silicon-labs/acc-uzb3/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Silicon Labs
 manufacturer_raw: Silicon Labs
 model_name: ACC-UZB3
 model_raw: ACC-UZB3
+same_as: null
 versions:
 - software: '6.10'
 via_devices: null

--- a/devices/zwave_js/ultraloq/u-bolt-pro-zwave/info.yaml
+++ b/devices/zwave_js/ultraloq/u-bolt-pro-zwave/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Ultraloq
 manufacturer_raw: Ultraloq
 model_name: U-BOLT-PRO-ZWAVE
 model_raw: U-BOLT-PRO-ZWAVE
+same_as: null
 versions:
 - software: 1.5.3
 via_devices: null

--- a/devices/zwave_js/z-wave-me/razberry-7/info.yaml
+++ b/devices/zwave_js/z-wave-me/razberry-7/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Z-Wave.me
 manufacturer_raw: Z-Wave.me
 model_name: RaZberry 7
 model_raw: RaZberry 7
+same_as: null
 versions:
 - software: '7.36'
 via_devices: null

--- a/devices/zwave_js/zooz/zen04-800lr/info.yaml
+++ b/devices/zwave_js/zooz/zen04-800lr/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN04 800LR
 model_raw: ZEN04 800LR
+same_as: null
 versions:
 - software: 2.20.1
 via_devices:

--- a/devices/zwave_js/zooz/zen04/info.yaml
+++ b/devices/zwave_js/zooz/zen04/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN04
 model_raw: ZEN04
+same_as: null
 versions:
 - software: 1.30.1
 via_devices: null

--- a/devices/zwave_js/zooz/zen14/info.yaml
+++ b/devices/zwave_js/zooz/zen14/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN14
 model_raw: ZEN14
+same_as: null
 versions:
 - software: 1.20.1
 via_devices: null

--- a/devices/zwave_js/zooz/zen16/info.yaml
+++ b/devices/zwave_js/zooz/zen16/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN16
 model_raw: ZEN16
+same_as: null
 versions:
 - software: 1.3.1
 via_devices: null

--- a/devices/zwave_js/zooz/zen20/info.yaml
+++ b/devices/zwave_js/zooz/zen20/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN20
 model_raw: ZEN20
+same_as: null
 versions:
 - software: 3.0.1
 via_devices: null

--- a/devices/zwave_js/zooz/zen37-800lr/info.yaml
+++ b/devices/zwave_js/zooz/zen37-800lr/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN37 800LR
 model_raw: ZEN37 800LR
+same_as: null
 versions:
 - software: 1.0.0
 via_devices:

--- a/devices/zwave_js/zooz/zen71/info.yaml
+++ b/devices/zwave_js/zooz/zen71/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN71
 model_raw: ZEN71
+same_as: null
 versions:
 - software: 1.3.1
 via_devices: null

--- a/devices/zwave_js/zooz/zen72/info.yaml
+++ b/devices/zwave_js/zooz/zen72/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZEN72
 model_raw: ZEN72
+same_as: null
 versions:
 - software: 10.40.2
 via_devices: null

--- a/devices/zwave_js/zooz/zse40-700/info.yaml
+++ b/devices/zwave_js/zooz/zse40-700/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZSE40 700
 model_raw: ZSE40 700
+same_as: null
 versions:
 - software: 32.32.1
 - software: 1.10.2

--- a/devices/zwave_js/zooz/zse42/info.yaml
+++ b/devices/zwave_js/zooz/zse42/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZSE42
 model_raw: ZSE42
+same_as: null
 versions:
 - software: 1.50.1
 - software: 1.40.1

--- a/devices/zwave_js/zooz/zse44/info.yaml
+++ b/devices/zwave_js/zooz/zse44/info.yaml
@@ -7,6 +7,7 @@ manufacturer_name: Zooz
 manufacturer_raw: Zooz
 model_name: ZSE44
 model_raw: ZSE44
+same_as: null
 versions:
 - software: 1.30.1
 via_devices: null

--- a/script/update_yaml.py
+++ b/script/update_yaml.py
@@ -10,7 +10,7 @@ ROOT_DIR = pathlib.Path(__file__).parent.parent.resolve()
 DEVICES_DIR = ROOT_DIR / "devices"
 
 NEW_KEYS = {
-    "via_devices": None,
+    "same_as": None,
 }
 
 

--- a/template/info.yaml
+++ b/template/info.yaml
@@ -7,5 +7,6 @@ manufacturer_name: ""
 manufacturer_raw: ""
 model_name: ""
 model_raw: ""
+same_as: null
 versions: []
 via_devices: null


### PR DESCRIPTION
Some devices are integrated in Home Assistant via different integrations. This adds support for a new `same_as` key. This key can contain a list of references to devices that are the same.