### PR TITLE
Update works with ha

### DIFF
--- a/database/aqara/devices/ag042/home-assistant/info.yaml
+++ b/database/aqara/devices/ag042/home-assistant/info.yaml
@@ -4,4 +4,5 @@ integrations:
   model_id: "14"
 has_configuration_url: false
 has_suggested_area: false
-is_works_with_ha: true
+is_works_with_ha:
+  matter: matter

--- a/database/aqara/devices/as056/home-assistant/info.yaml
+++ b/database/aqara/devices/as056/home-assistant/info.yaml
@@ -4,4 +4,5 @@ integrations:
   model_id: "21"
 has_configuration_url: false
 has_suggested_area: false
-is_works_with_ha: true
+is_works_with_ha:
+  matter: matter

--- a/database/aqara/devices/as057/home-assistant/info.yaml
+++ b/database/aqara/devices/as057/home-assistant/info.yaml
@@ -4,4 +4,5 @@ integrations:
   model_id: "263"
 has_configuration_url: false
 has_suggested_area: false
-is_works_with_ha: true
+is_works_with_ha:
+  matter: matter

--- a/database/awair/devices/awair-element/home-assistant/info.yaml
+++ b/database/awair/devices/awair-element/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: awair
   manufacturer: Awair
   model_id: awair-element
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/belkin/devices/belkin-insight-1-0/home-assistant/info.yaml
+++ b/database/belkin/devices/belkin-insight-1-0/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: wemo
   manufacturer: Belkin
   model_id: Belkin Insight 1.0
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/eve-systems/devices/20CAA9901/home-assistant/info.yaml
+++ b/database/eve-systems/devices/20CAA9901/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: matter
   manufacturer: Eve Systems
   model_id: '85'
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/roborock/devices/roborock-vacuum-a27/home-assistant/info.yaml
+++ b/database/roborock/devices/roborock-vacuum-a27/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: roborock
   manufacturer: Roborock
   model_id: roborock.vacuum.a27
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/roborock/devices/roborock-vacuum-a97/home-assistant/info.yaml
+++ b/database/roborock/devices/roborock-vacuum-a97/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: roborock
   manufacturer: Roborock
   model_id: roborock.vacuum.a97
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/samsung/devices/qn43ls03bafxza/home-assistant/info.yaml
+++ b/database/samsung/devices/qn43ls03bafxza/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: samsungtv
   manufacturer: Samsung
   model_id: QN43LS03BAFXZA
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/shgs-1/home-assistant/info.yaml
+++ b/database/shelly/devices/shgs-1/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SHGS-1
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/shwt-1/home-assistant/info.yaml
+++ b/database/shelly/devices/shwt-1/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SHWT-1
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/sndm-0013us/home-assistant/info.yaml
+++ b/database/shelly/devices/sndm-0013us/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SNDM-0013US
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/snsw-001p15ul/home-assistant/info.yaml
+++ b/database/shelly/devices/snsw-001p15ul/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SNSW-001P15UL
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/snsw-102p16eu/home-assistant/info.yaml
+++ b/database/shelly/devices/snsw-102p16eu/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SNSW-102P16EU
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/shelly/devices/spem-003cebeu/home-assistant/info.yaml
+++ b/database/shelly/devices/spem-003cebeu/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: shelly
   manufacturer: Shelly
   model_id: SPEM-003CEBEU
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/sonos/devices/s20/home-assistant/info.yaml
+++ b/database/sonos/devices/s20/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: sonos
   manufacturer: Sonos
   model_id: S20
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/sonos/devices/s24/home-assistant/info.yaml
+++ b/database/sonos/devices/s24/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: sonos
   manufacturer: Sonos
   model_id: S24
-is_works_with_ha: false
+is_works_with_ha: null

--- a/database/ubiquiti/devices/uvc-g3/home-assistant/info.yaml
+++ b/database/ubiquiti/devices/uvc-g3/home-assistant/info.yaml
@@ -4,4 +4,4 @@ integrations:
 - integration: unifiprotect
   manufacturer: Ubiquiti
   model_id: UVC G3
-is_works_with_ha: false
+is_works_with_ha: null

--- a/devfest/process/templates/device/home-assistant/info.yaml
+++ b/devfest/process/templates/device/home-assistant/info.yaml
@@ -1,4 +1,4 @@
 integrations: []
 has_configuration_url: false
 has_suggested_area: false
-is_works_with_ha: false
+is_works_with_ha: null

--- a/devfest/validate/data/home_assistant_device.py
+++ b/devfest/validate/data/home_assistant_device.py
@@ -18,7 +18,21 @@ INFO_SCHEMA = vol.Schema(
                 vol.Required("model_id"): str,
             }
         ],
-        vol.Required("is_works_with_ha"): bool,
+        vol.Required("is_works_with_ha"): vol.Any(
+            None,
+            # Dict mapping integration to the type of badge
+            {
+                str: vol.In(
+                    [
+                        "bluetooth",
+                        "local",
+                        "matter",
+                        "z-wave",
+                        "zigbee",
+                    ]
+                )
+            },
+        ),
     }
 )
 


### PR DESCRIPTION
We need to track with which integration a device is receiving what badge for Works with Home Assistant program. This migrates the `device/home-assistant/info.yaml` `works_with_ha` from a boolean to a dictionary. The dictionary maps `integration domain` => `badge type`. For example, we can have `airgradient => local` and `matter: matter`. 